### PR TITLE
Add VS Code extension release workflow

### DIFF
--- a/.github/workflows/release-vscode.yml
+++ b/.github/workflows/release-vscode.yml
@@ -1,0 +1,151 @@
+name: Release VS Code Extension
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish to VS Code Marketplace"
+        required: false
+        default: false
+        type: boolean
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            rust-target: x86_64-unknown-linux-gnu
+            code-target: linux-x64
+          - os: ubuntu-latest
+            rust-target: aarch64-unknown-linux-gnu
+            code-target: linux-arm64
+            cross: true
+          - os: macos-latest
+            rust-target: x86_64-apple-darwin
+            code-target: darwin-x64
+          - os: macos-latest
+            rust-target: aarch64-apple-darwin
+            code-target: darwin-arm64
+          - os: windows-latest
+            rust-target: x86_64-pc-windows-msvc
+            code-target: win32-x64
+          - os: windows-latest
+            rust-target: aarch64-pc-windows-msvc
+            code-target: win32-arm64
+
+    runs-on: ${{ matrix.os }}
+    name: Build (${{ matrix.code-target }})
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust-target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.rust-target }}
+
+      - name: Install cross-compilation tools
+        if: matrix.cross
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Build LSP server
+        run: cargo build --release --features lsp --bin clickhouse-lsp --target ${{ matrix.rust-target }}
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.cross && 'aarch64-linux-gnu-gcc' || '' }}
+
+      - name: Copy server binary (unix)
+        if: runner.os != 'Windows'
+        run: |
+          mkdir -p packages/vscode/server
+          cp target/${{ matrix.rust-target }}/release/clickhouse-lsp packages/vscode/server/
+          chmod +x packages/vscode/server/clickhouse-lsp
+
+      - name: Copy server binary (windows)
+        if: runner.os == 'Windows'
+        run: |
+          mkdir -p packages/vscode/server
+          cp target/${{ matrix.rust-target }}/release/clickhouse-lsp.exe packages/vscode/server/
+        shell: bash
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies and build extension
+        working-directory: packages/vscode
+        run: |
+          npm ci
+          npm run build
+
+      - name: Package extension
+        working-directory: packages/vscode
+        run: |
+          npx @vscode/vsce package --target ${{ matrix.code-target }} -o ../../clickhouse-analyzer-${{ matrix.code-target }}.vsix
+
+      - name: Upload .vsix artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vsix-${{ matrix.code-target }}
+          path: clickhouse-analyzer-${{ matrix.code-target }}.vsix
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.publish)
+    steps:
+      - name: Download all .vsix artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: vsix-*
+          merge-multiple: true
+          path: vsix
+
+      - name: List artifacts
+        run: ls -la vsix/
+
+      - name: Publish to VS Code Marketplace
+        run: |
+          npx @vscode/vsce publish --packagePath vsix/*.vsix
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Publish to Open VSX
+        run: |
+          for vsix in vsix/*.vsix; do
+            npx ovsx publish "$vsix" -p ${{ secrets.OVSX_PAT }}
+          done
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        if: env.OVSX_PAT != ''
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - name: Download all .vsix artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: vsix-*
+          merge-multiple: true
+          path: vsix
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: vsix/*.vsix
+          generate_release_notes: true

--- a/.github/workflows/release-vscode.yml
+++ b/.github/workflows/release-vscode.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Package extension
         working-directory: packages/vscode
         run: |
-          npx @vscode/vsce package --target ${{ matrix.code-target }} -o ../../clickhouse-analyzer-${{ matrix.code-target }}.vsix
+          npx @vscode/vsce package --pre-release --target ${{ matrix.code-target }} -o ../../clickhouse-analyzer-${{ matrix.code-target }}.vsix
 
       - name: Upload .vsix artifact
         uses: actions/upload-artifact@v4
@@ -117,7 +117,7 @@ jobs:
 
       - name: Publish to VS Code Marketplace
         run: |
-          npx @vscode/vsce publish --packagePath vsix/*.vsix
+          npx @vscode/vsce publish --pre-release --packagePath vsix/*.vsix
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 

--- a/packages/vscode/.vscodeignore
+++ b/packages/vscode/.vscodeignore
@@ -8,3 +8,5 @@ node_modules/**/*.md
 node_modules/**/*.map
 node_modules/**/LICENSE*
 node_modules/**/CHANGELOG*
+!server/
+!server/**

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -1,0 +1,46 @@
+# ClickHouse Analyzer — VS Code Extension
+
+> **This extension is experimental.** It is under active development and may have incomplete coverage or breaking changes between releases.
+
+A VS Code extension for ClickHouse SQL, powered by a native LSP server built on the [clickhouse-analyzer](https://github.com/ClickHouse/clickhouse-analyzer) parser.
+
+## Features
+
+- **Diagnostics** — parse errors shown as squiggly underlines with enriched messages (bracket matching, clause context)
+- **Formatting** — format ClickHouse SQL documents
+- **Semantic highlighting** — context-aware token coloring (keywords, functions, columns, types, tables, operators, strings, numbers, comments, parameters)
+- **Completions** — keyword, function, and type completions; schema-aware table and column completions when connected to a live ClickHouse instance
+- **Hover** — documentation for functions, settings, and data types
+- **Go to definition** — navigate to table definitions (requires live connection)
+
+## Getting Started
+
+1. Install the extension
+2. Open any `.sql`, `.clickhouse`, or `.ch.sql` file — the analyzer starts automatically
+
+The LSP server binary is bundled with the extension. No additional installation required.
+
+## Live Connection (Optional)
+
+For schema-aware completions (tables, columns), enable a connection to a running ClickHouse instance:
+
+```json
+{
+  "clickhouse-analyzer.connection.enabled": true,
+  "clickhouse-analyzer.connection.url": "http://localhost:8123",
+  "clickhouse-analyzer.connection.database": "default",
+  "clickhouse-analyzer.connection.username": "default",
+  "clickhouse-analyzer.connection.password": ""
+}
+```
+
+## Settings
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `clickhouse-analyzer.serverPath` | `""` | Path to a custom `clickhouse-lsp` binary. If empty, uses the bundled server. |
+| `clickhouse-analyzer.connection.enabled` | `false` | Enable live ClickHouse connection for schema-aware completions. |
+| `clickhouse-analyzer.connection.url` | `http://localhost:8123` | ClickHouse HTTP endpoint URL. |
+| `clickhouse-analyzer.connection.database` | `default` | Default database name. |
+| `clickhouse-analyzer.connection.username` | `default` | Username for authentication. |
+| `clickhouse-analyzer.connection.password` | `""` | Password for authentication. |

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -5,6 +5,10 @@
   "version": "0.1.0",
   "publisher": "ClickHouse",
   "homepage": "https://clickhouse.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ClickHouse/clickhouse-analyzer"
+  },
   "license": "Apache-2.0",
   "private": true,
   "engines": {
@@ -31,7 +35,7 @@
         "clickhouse-analyzer.serverPath": {
           "type": "string",
           "default": "",
-          "description": "Path to the clickhouse-lsp binary. If empty, searches $PATH."
+          "description": "Path to the clickhouse-lsp binary. If empty, uses the bundled server or searches $PATH."
         },
         "clickhouse-analyzer.connection.enabled": {
           "type": "boolean",
@@ -71,6 +75,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/vscode": "^1.75.0",
+    "@vscode/vsce": "^3.0.0",
     "typescript": "^5.0.0"
   }
 }

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -12,7 +12,7 @@
   "license": "Apache-2.0",
   "private": true,
   "engines": {
-    "vscode": "^1.75.0"
+    "vscode": "^1.80.0"
   },
   "categories": ["Programming Languages", "Linters", "Formatters"],
   "activationEvents": [

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -1,3 +1,5 @@
+import * as path from "path";
+import * as fs from "fs";
 import { workspace, window, ExtensionContext, StatusBarAlignment, StatusBarItem } from "vscode";
 import {
   LanguageClient,
@@ -9,10 +11,26 @@ import {
 let client: LanguageClient | undefined;
 let statusBarItem: StatusBarItem | undefined;
 
-export function activate(context: ExtensionContext) {
+function getServerPath(context: ExtensionContext): string {
   const config = workspace.getConfiguration("clickhouse-analyzer");
-  const serverPath =
-    config.get<string>("serverPath") || "clickhouse-lsp";
+  const configPath = config.get<string>("serverPath");
+  if (configPath) {
+    return configPath;
+  }
+
+  // Look for the bundled server binary
+  const ext = process.platform === "win32" ? ".exe" : "";
+  const bundledPath = path.join(context.extensionPath, "server", `clickhouse-lsp${ext}`);
+  if (fs.existsSync(bundledPath)) {
+    return bundledPath;
+  }
+
+  // Fall back to PATH
+  return "clickhouse-lsp";
+}
+
+export function activate(context: ExtensionContext) {
+  const serverPath = getServerPath(context);
 
   const run: Executable = {
     command: serverPath,


### PR DESCRIPTION
## Summary
- Adds `release-vscode.yml` GitHub Actions workflow that builds platform-specific `.vsix` packages with the `clickhouse-lsp` binary bundled inside (rust-analyzer pattern)
- Builds for 6 platforms: linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64, win32-arm64
- Updates the extension to prefer the bundled server binary before falling back to `$PATH`
- Publishes to VS Code Marketplace, Open VSX, and GitHub Releases on version tags (`v*`)
- Can also be triggered manually via `workflow_dispatch`
- **All releases are marked as pre-release** (`--pre-release` flag) so they show an experimental badge on the Marketplace. Remove the flag from the workflow when ready for stable releases.
- Adds a marketplace README (`packages/vscode/README.md`) with a prominent experimental warning

## How it works
1. **Build job** (matrix): Compiles `clickhouse-lsp` for each target, copies it into `packages/vscode/server/`, builds the TypeScript extension, packages a platform-specific `.vsix` via `vsce package --pre-release --target`
2. **Publish job**: Downloads all `.vsix` artifacts and publishes to VS Code Marketplace (requires `VSCE_PAT` secret) and optionally Open VSX (`OVSX_PAT` secret)
3. **Release job**: Creates a GitHub Release with all `.vsix` files attached

## Setup required
- Add `VSCE_PAT` secret (VS Code Marketplace personal access token)
- Optionally add `OVSX_PAT` secret for Open VSX publishing
- To release: push a tag like `git tag v0.1.0 && git push --tags`

## Test plan
- [ ] Trigger workflow manually via `workflow_dispatch` (without publish) to verify builds succeed
- [ ] Verify `.vsix` artifacts are produced for all 6 platforms
- [ ] Install a built `.vsix` locally and confirm the bundled LSP server starts
- [ ] Verify `serverPath` setting still overrides the bundled binary
- [ ] Confirm pre-release badge appears on the Marketplace listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)