### PR TITLE
Add VS Code sidebar for local ClickHouse server management

### DIFF
--- a/.github/workflows/release-vscode.yml
+++ b/.github/workflows/release-vscode.yml
@@ -1,0 +1,151 @@
+name: Release VS Code Extension
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish to VS Code Marketplace"
+        required: false
+        default: false
+        type: boolean
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            rust-target: x86_64-unknown-linux-gnu
+            code-target: linux-x64
+          - os: ubuntu-latest
+            rust-target: aarch64-unknown-linux-gnu
+            code-target: linux-arm64
+            cross: true
+          - os: macos-latest
+            rust-target: x86_64-apple-darwin
+            code-target: darwin-x64
+          - os: macos-latest
+            rust-target: aarch64-apple-darwin
+            code-target: darwin-arm64
+          - os: windows-latest
+            rust-target: x86_64-pc-windows-msvc
+            code-target: win32-x64
+          - os: windows-latest
+            rust-target: aarch64-pc-windows-msvc
+            code-target: win32-arm64
+
+    runs-on: ${{ matrix.os }}
+    name: Build (${{ matrix.code-target }})
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust-target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.rust-target }}
+
+      - name: Install cross-compilation tools
+        if: matrix.cross
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Build LSP server
+        run: cargo build --release --features lsp --bin clickhouse-lsp --target ${{ matrix.rust-target }}
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.cross && 'aarch64-linux-gnu-gcc' || '' }}
+
+      - name: Copy server binary (unix)
+        if: runner.os != 'Windows'
+        run: |
+          mkdir -p packages/vscode/server
+          cp target/${{ matrix.rust-target }}/release/clickhouse-lsp packages/vscode/server/
+          chmod +x packages/vscode/server/clickhouse-lsp
+
+      - name: Copy server binary (windows)
+        if: runner.os == 'Windows'
+        run: |
+          mkdir -p packages/vscode/server
+          cp target/${{ matrix.rust-target }}/release/clickhouse-lsp.exe packages/vscode/server/
+        shell: bash
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies and build extension
+        working-directory: packages/vscode
+        run: |
+          npm ci
+          npm run build
+
+      - name: Package extension
+        working-directory: packages/vscode
+        run: |
+          npx @vscode/vsce package --target ${{ matrix.code-target }} -o ../../clickhouse-analyzer-${{ matrix.code-target }}.vsix
+
+      - name: Upload .vsix artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vsix-${{ matrix.code-target }}
+          path: clickhouse-analyzer-${{ matrix.code-target }}.vsix
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.publish)
+    steps:
+      - name: Download all .vsix artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: vsix-*
+          merge-multiple: true
+          path: vsix
+
+      - name: List artifacts
+        run: ls -la vsix/
+
+      - name: Publish to VS Code Marketplace
+        run: |
+          npx @vscode/vsce publish --packagePath vsix/*.vsix
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Publish to Open VSX
+        run: |
+          for vsix in vsix/*.vsix; do
+            npx ovsx publish "$vsix" -p ${{ secrets.OVSX_PAT }}
+          done
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        if: env.OVSX_PAT != ''
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - name: Download all .vsix artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: vsix-*
+          merge-multiple: true
+          path: vsix
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: vsix/*.vsix
+          generate_release_notes: true

--- a/.github/workflows/release-vscode.yml
+++ b/.github/workflows/release-vscode.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Package extension
         working-directory: packages/vscode
         run: |
-          npx @vscode/vsce package --target ${{ matrix.code-target }} -o ../../clickhouse-analyzer-${{ matrix.code-target }}.vsix
+          npx @vscode/vsce package --pre-release --target ${{ matrix.code-target }} -o ../../clickhouse-analyzer-${{ matrix.code-target }}.vsix
 
       - name: Upload .vsix artifact
         uses: actions/upload-artifact@v4
@@ -117,7 +117,7 @@ jobs:
 
       - name: Publish to VS Code Marketplace
         run: |
-          npx @vscode/vsce publish --packagePath vsix/*.vsix
+          npx @vscode/vsce publish --pre-release --packagePath vsix/*.vsix
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 

--- a/packages/vscode/.vscode/launch.json
+++ b/packages/vscode/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "outFiles": ["${workspaceFolder}/out/**/*.js"],
+      "preLaunchTask": "npm: build"
+    }
+  ]
+}

--- a/packages/vscode/.vscodeignore
+++ b/packages/vscode/.vscodeignore
@@ -8,3 +8,5 @@ node_modules/**/*.md
 node_modules/**/*.map
 node_modules/**/LICENSE*
 node_modules/**/CHANGELOG*
+!server/
+!server/**

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -1,0 +1,46 @@
+# ClickHouse Analyzer — VS Code Extension
+
+> **This extension is experimental.** It is under active development and may have incomplete coverage or breaking changes between releases.
+
+A VS Code extension for ClickHouse SQL, powered by a native LSP server built on the [clickhouse-analyzer](https://github.com/ClickHouse/clickhouse-analyzer) parser.
+
+## Features
+
+- **Diagnostics** — parse errors shown as squiggly underlines with enriched messages (bracket matching, clause context)
+- **Formatting** — format ClickHouse SQL documents
+- **Semantic highlighting** — context-aware token coloring (keywords, functions, columns, types, tables, operators, strings, numbers, comments, parameters)
+- **Completions** — keyword, function, and type completions; schema-aware table and column completions when connected to a live ClickHouse instance
+- **Hover** — documentation for functions, settings, and data types
+- **Go to definition** — navigate to table definitions (requires live connection)
+
+## Getting Started
+
+1. Install the extension
+2. Open any `.sql`, `.clickhouse`, or `.ch.sql` file — the analyzer starts automatically
+
+The LSP server binary is bundled with the extension. No additional installation required.
+
+## Live Connection (Optional)
+
+For schema-aware completions (tables, columns), enable a connection to a running ClickHouse instance:
+
+```json
+{
+  "clickhouse-analyzer.connection.enabled": true,
+  "clickhouse-analyzer.connection.url": "http://localhost:8123",
+  "clickhouse-analyzer.connection.database": "default",
+  "clickhouse-analyzer.connection.username": "default",
+  "clickhouse-analyzer.connection.password": ""
+}
+```
+
+## Settings
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `clickhouse-analyzer.serverPath` | `""` | Path to a custom `clickhouse-lsp` binary. If empty, uses the bundled server. |
+| `clickhouse-analyzer.connection.enabled` | `false` | Enable live ClickHouse connection for schema-aware completions. |
+| `clickhouse-analyzer.connection.url` | `http://localhost:8123` | ClickHouse HTTP endpoint URL. |
+| `clickhouse-analyzer.connection.database` | `default` | Default database name. |
+| `clickhouse-analyzer.connection.username` | `default` | Username for authentication. |
+| `clickhouse-analyzer.connection.password` | `""` | Password for authentication. |

--- a/packages/vscode/icons/clickhouse.svg
+++ b/packages/vscode/icons/clickhouse.svg
@@ -1,0 +1,7 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="1" y="2" width="3" height="20" rx="0.5" fill="#C8C8C8"/>
+  <rect x="6" y="2" width="3" height="20" rx="0.5" fill="#C8C8C8"/>
+  <rect x="11" y="2" width="3" height="20" rx="0.5" fill="#C8C8C8"/>
+  <rect x="16" y="2" width="3" height="20" rx="0.5" fill="#C8C8C8"/>
+  <rect x="21" y="9.5" width="3" height="5" rx="0.5" fill="#C8C8C8"/>
+</svg>

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -5,6 +5,10 @@
   "version": "0.1.0",
   "publisher": "ClickHouse",
   "homepage": "https://clickhouse.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ClickHouse/clickhouse-analyzer"
+  },
   "license": "Apache-2.0",
   "private": true,
   "engines": {
@@ -31,7 +35,7 @@
         "clickhouse-analyzer.serverPath": {
           "type": "string",
           "default": "",
-          "description": "Path to the clickhouse-lsp binary. If empty, searches $PATH."
+          "description": "Path to the clickhouse-lsp binary. If empty, uses the bundled server or searches $PATH."
         },
         "clickhouse-analyzer.connection.enabled": {
           "type": "boolean",
@@ -71,6 +75,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/vscode": "^1.75.0",
+    "@vscode/vsce": "^3.0.0",
     "typescript": "^5.0.0"
   }
 }

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -12,7 +12,7 @@
   "license": "Apache-2.0",
   "private": true,
   "engines": {
-    "vscode": "^1.75.0"
+    "vscode": "^1.80.0"
   },
   "categories": ["Programming Languages", "Linters", "Formatters"],
   "activationEvents": [

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -17,16 +17,234 @@
   "categories": ["Programming Languages", "Linters", "Formatters"],
   "activationEvents": [
     "onLanguage:sql",
-    "onLanguage:clickhouse"
+    "onLanguage:clickhouse",
+    "onView:clickhouse-servers"
   ],
   "main": "./out/extension.js",
   "contributes": {
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "clickhouse-ctl",
+          "title": "ClickHouse",
+          "icon": "icons/clickhouse.svg"
+        }
+      ]
+    },
+    "views": {
+      "clickhouse-ctl": [
+        {
+          "id": "clickhouse-servers",
+          "name": "Local Servers"
+        },
+        {
+          "id": "clickhouse-versions",
+          "name": "Installed Versions"
+        }
+      ]
+    },
+    "viewsWelcome": [
+      {
+        "view": "clickhouse-servers",
+        "contents": "Open a folder to manage local ClickHouse servers.\n[Open Folder](command:vscode.openFolder)",
+        "when": "workspaceFolderCount == 0"
+      },
+      {
+        "view": "clickhouse-servers",
+        "contents": "Initialize ClickHouse in this project to create and manage local servers.\n[Initialize ClickHouse](command:clickhouse-analyzer.initProject)",
+        "when": "workspaceFolderCount > 0 && !clickhouse-analyzer.projectInitialized"
+      },
+      {
+        "view": "clickhouse-servers",
+        "contents": "No local ClickHouse servers found.\n[Create Server](command:clickhouse-analyzer.createServer)",
+        "when": "workspaceFolderCount > 0 && clickhouse-analyzer.projectInitialized && clickhouse-analyzer.ctlInstalled"
+      },
+      {
+        "view": "clickhouse-servers",
+        "contents": "[clickhousectl](https://clickhouse.com/docs/install) is required to manage local servers.\n[Install clickhousectl](command:clickhouse-analyzer.installCtl)",
+        "when": "!clickhouse-analyzer.ctlInstalled"
+      },
+      {
+        "view": "clickhouse-versions",
+        "contents": "[clickhousectl](https://clickhouse.com/docs/install) is required to manage versions.\n[Install clickhousectl](command:clickhouse-analyzer.installCtl)",
+        "when": "!clickhouse-analyzer.ctlInstalled"
+      },
+      {
+        "view": "clickhouse-versions",
+        "contents": "No ClickHouse versions installed.\n[Install Version](command:clickhouse-analyzer.installVersion)",
+        "when": "clickhouse-analyzer.ctlInstalled"
+      }
+    ],
+    "commands": [
+      {
+        "command": "clickhouse-analyzer.installCtl",
+        "title": "Install clickhousectl CLI",
+        "category": "ClickHouse"
+      },
+      {
+        "command": "clickhouse-analyzer.initProject",
+        "title": "Initialize ClickHouse in Project",
+        "category": "ClickHouse",
+        "icon": "$(folder-opened)"
+      },
+      {
+        "command": "clickhouse-analyzer.installVersion",
+        "title": "Install ClickHouse Version",
+        "category": "ClickHouse",
+        "icon": "$(add)"
+      },
+      {
+        "command": "clickhouse-analyzer.useVersion",
+        "title": "Use as Default",
+        "category": "ClickHouse",
+        "icon": "$(star-full)"
+      },
+      {
+        "command": "clickhouse-analyzer.removeVersion",
+        "title": "Remove Version",
+        "category": "ClickHouse",
+        "icon": "$(trash)"
+      },
+      {
+        "command": "clickhouse-analyzer.createServer",
+        "title": "Create Local Server",
+        "category": "ClickHouse",
+        "icon": "$(add)"
+      },
+      {
+        "command": "clickhouse-analyzer.startServer",
+        "title": "Start Server",
+        "category": "ClickHouse",
+        "icon": "$(debug-start)"
+      },
+      {
+        "command": "clickhouse-analyzer.stopServer",
+        "title": "Stop Server",
+        "category": "ClickHouse",
+        "icon": "$(debug-stop)"
+      },
+      {
+        "command": "clickhouse-analyzer.deleteServer",
+        "title": "Delete Server",
+        "category": "ClickHouse",
+        "icon": "$(trash)"
+      },
+      {
+        "command": "clickhouse-analyzer.connectLsp",
+        "title": "Use as LSP Connection",
+        "category": "ClickHouse",
+        "icon": "$(plug)"
+      },
+      {
+        "command": "clickhouse-analyzer.addToEnv",
+        "title": "Add to .env",
+        "category": "ClickHouse",
+        "icon": "$(file-code)"
+      },
+      {
+        "command": "clickhouse-analyzer.refreshServers",
+        "title": "Refresh",
+        "category": "ClickHouse",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "clickhouse-analyzer.refreshVersions",
+        "title": "Refresh",
+        "category": "ClickHouse",
+        "icon": "$(refresh)"
+      }
+    ],
+    "menus": {
+      "view/title": [
+        {
+          "command": "clickhouse-analyzer.createServer",
+          "when": "view == clickhouse-servers && clickhouse-analyzer.projectInitialized",
+          "group": "navigation"
+        },
+        {
+          "command": "clickhouse-analyzer.refreshServers",
+          "when": "view == clickhouse-servers && clickhouse-analyzer.projectInitialized",
+          "group": "navigation"
+        },
+        {
+          "command": "clickhouse-analyzer.installVersion",
+          "when": "view == clickhouse-versions",
+          "group": "navigation"
+        },
+        {
+          "command": "clickhouse-analyzer.refreshVersions",
+          "when": "view == clickhouse-versions",
+          "group": "navigation"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "clickhouse-analyzer.startServer",
+          "when": "view == clickhouse-servers && viewItem == server-stopped",
+          "group": "inline"
+        },
+        {
+          "command": "clickhouse-analyzer.stopServer",
+          "when": "view == clickhouse-servers && viewItem == server-running",
+          "group": "inline"
+        },
+        {
+          "command": "clickhouse-analyzer.connectLsp",
+          "when": "view == clickhouse-servers && viewItem == server-running",
+          "group": "inline"
+        },
+        {
+          "command": "clickhouse-analyzer.addToEnv",
+          "when": "view == clickhouse-servers && viewItem == server-running",
+          "group": "inline"
+        },
+        {
+          "command": "clickhouse-analyzer.stopServer",
+          "when": "view == clickhouse-servers && viewItem == server-running",
+          "group": "context@1"
+        },
+        {
+          "command": "clickhouse-analyzer.connectLsp",
+          "when": "view == clickhouse-servers && viewItem == server-running",
+          "group": "context@2"
+        },
+        {
+          "command": "clickhouse-analyzer.addToEnv",
+          "when": "view == clickhouse-servers && viewItem == server-running",
+          "group": "context@3"
+        },
+        {
+          "command": "clickhouse-analyzer.deleteServer",
+          "when": "view == clickhouse-servers && viewItem =~ /^server-/",
+          "group": "context@4"
+        },
+        {
+          "command": "clickhouse-analyzer.removeVersion",
+          "when": "view == clickhouse-versions && viewItem =~ /^version/",
+          "group": "inline@2"
+        },
+        {
+          "command": "clickhouse-analyzer.useVersion",
+          "when": "view == clickhouse-versions && viewItem == version",
+          "group": "inline@1"
+        },
+        {
+          "command": "clickhouse-analyzer.useVersion",
+          "when": "view == clickhouse-versions && viewItem == version",
+          "group": "context"
+        }
+      ]
+    },
     "languages": [
       {
         "id": "clickhouse",
         "aliases": ["ClickHouse SQL", "clickhouse"],
         "extensions": [".clickhouse", ".ch.sql"],
-        "configuration": "./language-configuration.json"
+        "configuration": "./language-configuration.json",
+        "icon": {
+          "light": "./icons/clickhouse.svg",
+          "dark": "./icons/clickhouse.svg"
+        }
       }
     ],
     "configuration": {

--- a/packages/vscode/src/ctl.ts
+++ b/packages/vscode/src/ctl.ts
@@ -1,0 +1,201 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+import * as os from "os";
+import * as path from "path";
+import * as fs from "fs";
+import * as vscode from "vscode";
+
+const execFileAsync = promisify(execFile);
+
+let outputChannel: vscode.OutputChannel | undefined;
+
+function log(msg: string): void {
+  if (!outputChannel) {
+    outputChannel = vscode.window.createOutputChannel("ClickHouse CTL");
+  }
+  outputChannel.appendLine(`[${new Date().toISOString()}] ${msg}`);
+}
+
+export interface ServerInfo {
+  name: string;
+  status: "running" | "stopped";
+  httpPort?: string;
+  tcpPort?: string;
+  version?: string;
+  pid?: string;
+}
+
+export interface VersionInfo {
+  version: string;
+  active: boolean;
+}
+
+/**
+ * Resolves the path to the clickhousectl binary.
+ * Checks common install locations before falling back to PATH.
+ */
+function getCtlPath(): string {
+  const home = os.homedir();
+  const candidates = [
+    path.join(home, ".local", "bin", "clickhousectl"),
+    path.join(home, ".local", "bin", "chctl"),
+  ];
+  for (const p of candidates) {
+    if (fs.existsSync(p)) {
+      return p;
+    }
+  }
+  return "clickhousectl";
+}
+
+async function runCtl(args: string[], cwd?: string): Promise<string> {
+  const bin = getCtlPath();
+  log(`exec: ${bin} ${args.join(" ")}${cwd ? ` (cwd: ${cwd})` : ""}`);
+  try {
+    const { stdout, stderr } = await execFileAsync(bin, args, {
+      timeout: 60_000,
+      cwd,
+      env: { ...process.env, NO_COLOR: "1" },
+    });
+    if (stderr) log(`stderr: ${stderr.trim()}`);
+    log(`stdout: ${stdout.trim()}`);
+    return stdout.trim();
+  } catch (e: any) {
+    log(`error: ${e.message}`);
+    if (e.stderr) log(`stderr: ${e.stderr}`);
+    throw e;
+  }
+}
+
+async function runCtlJson(args: string[], cwd?: string): Promise<any> {
+  const raw = await runCtl([...args, "--json"], cwd);
+  try {
+    return JSON.parse(raw);
+  } catch {
+    log(`JSON parse failed for: ${raw}`);
+    throw new Error(`Failed to parse JSON from chctl: ${raw.substring(0, 200)}`);
+  }
+}
+
+/** Check whether clickhousectl is available. */
+export async function isCtlInstalled(): Promise<boolean> {
+  try {
+    await runCtl(["--version"]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Check whether the project directory has been initialized with `chctl local init`. */
+export function isInitialized(workspaceRoot: string): boolean {
+  return fs.existsSync(path.join(workspaceRoot, ".clickhouse"));
+}
+
+/** Initialize clickhousectl in a project directory. */
+export async function init(workspaceRoot: string): Promise<string> {
+  return runCtl(["local", "init"], workspaceRoot);
+}
+
+// ── Version commands (global, no cwd needed) ───────────────────────
+
+/** List installed ClickHouse versions. */
+export async function listVersions(): Promise<VersionInfo[]> {
+  try {
+    const data = await runCtlJson(["local", "list"]);
+    log(`listVersions raw data: ${JSON.stringify(data)}`);
+    const arr = Array.isArray(data) ? data : (data.versions ?? data.items ?? data.installed ?? []);
+    return arr.map((item: any) => {
+      log(`listVersions item: ${JSON.stringify(item)}`);
+      return {
+        version: String(item.version ?? item.name ?? item),
+        active: Boolean(item.active ?? item.is_active ?? item.default ?? item.selected ?? false),
+      };
+    });
+  } catch (e: any) {
+    log(`listVersions failed: ${e.message}`);
+    return [];
+  }
+}
+
+/** Install a ClickHouse version. */
+export async function installVersion(version: string): Promise<string> {
+  return runCtl(["local", "install", version]);
+}
+
+/** Remove a ClickHouse version. */
+export async function removeVersion(version: string): Promise<string> {
+  return runCtl(["local", "remove", version]);
+}
+
+/** Set the active/default ClickHouse version. */
+export async function useVersion(version: string): Promise<string> {
+  return runCtl(["local", "use", version]);
+}
+
+/** List available remote versions. */
+export async function listRemoteVersions(): Promise<string[]> {
+  try {
+    const data = await runCtlJson(["local", "list", "--remote"]);
+    const arr = Array.isArray(data) ? data : (data.versions ?? data.items ?? []);
+    return arr.map((item: any) => String(item.version ?? item.name ?? item));
+  } catch (e: any) {
+    log(`listRemoteVersions failed: ${e.message}`);
+    return [];
+  }
+}
+
+// ── Server commands (project-scoped, require cwd) ──────────────────
+
+/** List local servers in the given project directory. */
+export async function listServers(cwd: string): Promise<ServerInfo[]> {
+  try {
+    const data = await runCtlJson(["local", "server", "list"], cwd);
+    log(`listServers raw data: ${JSON.stringify(data)}`);
+    const arr = Array.isArray(data) ? data : (data.servers ?? data.items ?? []);
+    return arr.map((item: any) => {
+      log(`listServers item keys: ${Object.keys(item).join(", ")} = ${JSON.stringify(item)}`);
+      return {
+        name: String(item.name),
+        status: (item.running === true || String(item.status ?? "").toLowerCase().includes("running"))
+          ? "running" as const
+          : "stopped" as const,
+        httpPort: item.http_port != null ? String(item.http_port) : undefined,
+        tcpPort: item.tcp_port != null ? String(item.tcp_port) : undefined,
+        version: item.version != null ? String(item.version) : undefined,
+        pid: item.pid != null ? String(item.pid) : undefined,
+      };
+    });
+  } catch (e: any) {
+    log(`listServers failed: ${e.message}`);
+    return [];
+  }
+}
+
+/** Create and start a new server. */
+export async function createServer(
+  cwd: string,
+  name: string,
+  version?: string,
+): Promise<string> {
+  const args = ["local", "server", "start", "--name", name];
+  if (version) {
+    args.push("--version", version);
+  }
+  return runCtl(args, cwd);
+}
+
+/** Start an existing server. */
+export async function startServer(cwd: string, name: string): Promise<string> {
+  return runCtl(["local", "server", "start", "--name", name], cwd);
+}
+
+/** Stop a server. */
+export async function stopServer(cwd: string, name: string): Promise<string> {
+  return runCtl(["local", "server", "stop", name], cwd);
+}
+
+/** Remove a server and its data. */
+export async function deleteServer(cwd: string, name: string): Promise<string> {
+  return runCtl(["local", "server", "remove", name], cwd);
+}

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -1,3 +1,5 @@
+import * as path from "path";
+import * as fs from "fs";
 import { workspace, window, ExtensionContext, StatusBarAlignment, StatusBarItem } from "vscode";
 import {
   LanguageClient,
@@ -9,10 +11,26 @@ import {
 let client: LanguageClient | undefined;
 let statusBarItem: StatusBarItem | undefined;
 
-export function activate(context: ExtensionContext) {
+function getServerPath(context: ExtensionContext): string {
   const config = workspace.getConfiguration("clickhouse-analyzer");
-  const serverPath =
-    config.get<string>("serverPath") || "clickhouse-lsp";
+  const configPath = config.get<string>("serverPath");
+  if (configPath) {
+    return configPath;
+  }
+
+  // Look for the bundled server binary
+  const ext = process.platform === "win32" ? ".exe" : "";
+  const bundledPath = path.join(context.extensionPath, "server", `clickhouse-lsp${ext}`);
+  if (fs.existsSync(bundledPath)) {
+    return bundledPath;
+  }
+
+  // Fall back to PATH
+  return "clickhouse-lsp";
+}
+
+export function activate(context: ExtensionContext) {
+  const serverPath = getServerPath(context);
 
   const run: Executable = {
     command: serverPath,

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -1,12 +1,15 @@
 import * as path from "path";
 import * as fs from "fs";
-import { workspace, window, ExtensionContext, StatusBarAlignment, StatusBarItem } from "vscode";
+import * as os from "os";
+import { workspace, window, commands, ExtensionContext, StatusBarAlignment, StatusBarItem, Uri } from "vscode";
 import {
   LanguageClient,
   LanguageClientOptions,
   ServerOptions,
   Executable,
 } from "vscode-languageclient/node";
+import * as ctl from "./ctl";
+import { ServerTreeProvider, VersionTreeProvider } from "./sidebar";
 
 let client: LanguageClient | undefined;
 let statusBarItem: StatusBarItem | undefined;
@@ -29,7 +32,14 @@ function getServerPath(context: ExtensionContext): string {
   return "clickhouse-lsp";
 }
 
+/** Returns the first workspace folder path, or undefined if none open. */
+function getWorkspaceRoot(): string | undefined {
+  return workspace.workspaceFolders?.[0]?.uri.fsPath;
+}
+
 export function activate(context: ExtensionContext) {
+  // ── LSP client setup ─────────────────────────────────────────────
+
   const serverPath = getServerPath(context);
 
   const run: Executable = {
@@ -58,22 +68,20 @@ export function activate(context: ExtensionContext) {
     clientOptions,
   );
 
-  // Status bar item showing connection state
+  // ── Status bar ───────────────────────────────────────────────────
+
   statusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, 100);
   statusBarItem.text = "$(database) CH: Offline";
   statusBarItem.tooltip = "ClickHouse Analyzer - using compiled-in metadata";
   statusBarItem.show();
   context.subscriptions.push(statusBarItem);
 
-  // Update status bar when configuration changes
   workspace.onDidChangeConfiguration((e) => {
     if (e.affectsConfiguration("clickhouse-analyzer.connection")) {
       updateStatusBar();
     }
   });
 
-  // Register the log listener before starting so early messages
-  // (e.g. "Connected to ClickHouse") are not missed.
   client.onNotification("window/logMessage", (params: { type: number; message: string }) => {
     if (params.message.includes("Connected to ClickHouse")) {
       const version = params.message.match(/ClickHouse (\S+)/)?.[1] || "";
@@ -95,6 +103,410 @@ export function activate(context: ExtensionContext) {
   });
 
   client.start();
+
+  // ── Workspace & project state ────────────────────────────────────
+
+  const serverTree = new ServerTreeProvider();
+  const versionTree = new VersionTreeProvider();
+
+  async function refreshCtlState() {
+    const installed = await ctl.isCtlInstalled();
+    commands.executeCommand("setContext", "clickhouse-analyzer.ctlInstalled", installed);
+  }
+
+  function refreshProjectState() {
+    const root = getWorkspaceRoot();
+    const initialized = root ? ctl.isInitialized(root) : false;
+    commands.executeCommand("setContext", "clickhouse-analyzer.projectInitialized", initialized);
+    serverTree.workspaceRoot = initialized ? root : undefined;
+  }
+
+  // Set initial state
+  refreshCtlState();
+  refreshProjectState();
+
+  // Re-check when workspace folders change (open/close folder)
+  context.subscriptions.push(
+    workspace.onDidChangeWorkspaceFolders(() => refreshProjectState()),
+  );
+
+  // Watch for .clickhouse directory creation (e.g. init from terminal)
+  const root = getWorkspaceRoot();
+  if (root) {
+    const watcher = workspace.createFileSystemWatcher(
+      new (require("vscode").RelativePattern)(root, ".clickhouse/**"),
+    );
+    watcher.onDidCreate(() => refreshProjectState());
+    watcher.onDidDelete(() => refreshProjectState());
+    context.subscriptions.push(watcher);
+  }
+
+  // ── Sidebar tree views ───────────────────────────────────────────
+
+  const serverView = window.createTreeView("clickhouse-servers", {
+    treeDataProvider: serverTree,
+    showCollapseAll: false,
+  });
+  const versionView = window.createTreeView("clickhouse-versions", {
+    treeDataProvider: versionTree,
+    showCollapseAll: false,
+  });
+
+  context.subscriptions.push(serverView, versionView);
+
+  // ── Commands ─────────────────────────────────────────────────────
+
+  context.subscriptions.push(
+    commands.registerCommand("clickhouse-analyzer.refreshServers", async () => {
+      await refreshCtlState();
+      refreshProjectState();
+      await serverTree.reload();
+    }),
+    commands.registerCommand("clickhouse-analyzer.refreshVersions", async () => {
+      await refreshCtlState();
+      await versionTree.reload();
+    }),
+
+    commands.registerCommand("clickhouse-analyzer.installCtl", async () => {
+      const installed = await ctl.isCtlInstalled();
+      if (installed) {
+        window.showInformationMessage("clickhousectl is already installed.");
+        return;
+      }
+
+      const choice = await window.showInformationMessage(
+        "Install clickhousectl via the official install script?",
+        "Install",
+        "Cancel",
+      );
+      if (choice !== "Install") return;
+
+      let terminal = window.terminals.find((t) => t.name === "clickhousectl");
+      if (!terminal) {
+        terminal = window.createTerminal("clickhousectl");
+      }
+      terminal.show();
+      terminal.sendText("curl -fsSL https://clickhouse.com/cli | sh");
+
+      window.showInformationMessage(
+        "Installing clickhousectl… Refresh the sidebar once complete.",
+      );
+    }),
+
+    commands.registerCommand("clickhouse-analyzer.initProject", async () => {
+      if (!(await ensureCtl())) return;
+
+      const wsRoot = getWorkspaceRoot();
+      if (!wsRoot) {
+        window.showErrorMessage("Open a folder first to initialize ClickHouse.");
+        return;
+      }
+
+      if (ctl.isInitialized(wsRoot)) {
+        window.showInformationMessage("ClickHouse is already initialized in this project.");
+        refreshProjectState();
+        return;
+      }
+
+      await window.withProgress(
+        { location: { viewId: "clickhouse-servers" }, title: "Initializing ClickHouse…" },
+        async () => {
+          try {
+            await ctl.init(wsRoot);
+            refreshProjectState();
+            await serverTree.reload();
+            window.showInformationMessage("ClickHouse initialized in this project.");
+          } catch (e: any) {
+            window.showErrorMessage(`Failed to initialize: ${e.message}`);
+          }
+        },
+      );
+    }),
+
+    commands.registerCommand("clickhouse-analyzer.installVersion", async () => {
+      if (!(await ensureCtl())) return;
+
+      const version = await window.showInputBox({
+        prompt: "ClickHouse version to install (e.g. stable, lts, 25.3)",
+        placeHolder: "stable",
+        value: "stable",
+      });
+      if (!version) return;
+
+      await window.withProgress(
+        { location: { viewId: "clickhouse-versions" }, title: `Installing ${version}…` },
+        async () => {
+          try {
+            await ctl.installVersion(version);
+            window.showInformationMessage(`ClickHouse ${version} installed.`);
+            await versionTree.reload();
+          } catch (e: any) {
+            window.showErrorMessage(`Failed to install: ${e.message}`);
+          }
+        },
+      );
+    }),
+
+    commands.registerCommand("clickhouse-analyzer.useVersion", async (item) => {
+      if (!(await ensureCtl())) return;
+      const version: string = item?.info?.version;
+      if (!version) return;
+
+      try {
+        await ctl.useVersion(version);
+        window.showInformationMessage(`Default ClickHouse version set to ${version}.`);
+        await versionTree.reload();
+      } catch (e: any) {
+        window.showErrorMessage(`Failed to set version: ${e.message}`);
+      }
+    }),
+
+    commands.registerCommand("clickhouse-analyzer.removeVersion", async (item) => {
+      if (!(await ensureCtl())) return;
+      const version: string = item?.info?.version;
+      if (!version) return;
+
+      const confirm = await window.showWarningMessage(
+        `Remove ClickHouse ${version}?`,
+        { modal: true },
+        "Remove",
+      );
+      if (confirm !== "Remove") return;
+
+      try {
+        await ctl.removeVersion(version);
+        window.showInformationMessage(`ClickHouse ${version} removed.`);
+        await versionTree.reload();
+      } catch (e: any) {
+        window.showErrorMessage(`Failed to remove: ${e.message}`);
+      }
+    }),
+
+    commands.registerCommand("clickhouse-analyzer.createServer", async () => {
+      if (!(await ensureCtl())) return;
+      const wsRoot = requireWorkspace();
+      if (!wsRoot) return;
+
+      const name = await window.showInputBox({
+        prompt: "Server name",
+        placeHolder: "default",
+        value: "default",
+      });
+      if (!name) return;
+
+      const versions = await ctl.listVersions();
+      let version: string | undefined;
+      if (versions.length > 0) {
+        const picked = await window.showQuickPick(
+          versions.map((v) => ({
+            label: v.version,
+            description: v.active ? "(active)" : "",
+          })),
+          { placeHolder: "Select ClickHouse version (or Escape for default)" },
+        );
+        version = picked?.label;
+      }
+
+      await window.withProgress(
+        { location: { viewId: "clickhouse-servers" }, title: `Creating server ${name}…` },
+        async () => {
+          try {
+            await ctl.createServer(wsRoot, name, version);
+            window.showInformationMessage(`Server "${name}" created and started.`);
+            await serverTree.reload();
+          } catch (e: any) {
+            window.showErrorMessage(`Failed to create server: ${e.message}`);
+          }
+        },
+      );
+    }),
+
+    commands.registerCommand("clickhouse-analyzer.startServer", async (item) => {
+      if (!(await ensureCtl())) return;
+      const wsRoot = requireWorkspace();
+      if (!wsRoot) return;
+      const name: string = item?.server?.name;
+      if (!name) return;
+
+      await window.withProgress(
+        { location: { viewId: "clickhouse-servers" }, title: `Starting ${name}…` },
+        async () => {
+          try {
+            await ctl.startServer(wsRoot, name);
+            await serverTree.reload();
+          } catch (e: any) {
+            window.showErrorMessage(`Failed to start server: ${e.message}`);
+          }
+        },
+      );
+    }),
+
+    commands.registerCommand("clickhouse-analyzer.stopServer", async (item) => {
+      if (!(await ensureCtl())) return;
+      const wsRoot = requireWorkspace();
+      if (!wsRoot) return;
+      const name: string = item?.server?.name;
+      if (!name) return;
+
+      try {
+        await ctl.stopServer(wsRoot, name);
+        if (serverTree.connectedServer === name) {
+          serverTree.connectedServer = undefined;
+          await disconnectLsp();
+        }
+        await serverTree.reload();
+      } catch (e: any) {
+        window.showErrorMessage(`Failed to stop server: ${e.message}`);
+      }
+    }),
+
+    commands.registerCommand("clickhouse-analyzer.deleteServer", async (item) => {
+      if (!(await ensureCtl())) return;
+      const wsRoot = requireWorkspace();
+      if (!wsRoot) return;
+      const name: string = item?.server?.name;
+      if (!name) return;
+
+      const confirm = await window.showWarningMessage(
+        `Delete server "${name}"? This removes all its data.`,
+        { modal: true },
+        "Delete",
+      );
+      if (confirm !== "Delete") return;
+
+      try {
+        // Stop first if running
+        if (item.server.status === "running") {
+          await ctl.stopServer(wsRoot, name);
+        }
+        await ctl.deleteServer(wsRoot, name);
+        if (serverTree.connectedServer === name) {
+          serverTree.connectedServer = undefined;
+          await disconnectLsp();
+        }
+        window.showInformationMessage(`Server "${name}" deleted.`);
+        await serverTree.reload();
+      } catch (e: any) {
+        window.showErrorMessage(`Failed to delete server: ${e.message}`);
+      }
+    }),
+
+    commands.registerCommand("clickhouse-analyzer.connectLsp", async (item) => {
+      const server: ctl.ServerInfo = item?.server;
+      if (!server || server.status !== "running") {
+        window.showErrorMessage("Server must be running to connect.");
+        return;
+      }
+
+      const port = server.httpPort || "8123";
+      const url = `http://localhost:${port}`;
+
+      const config = workspace.getConfiguration("clickhouse-analyzer");
+      await config.update("connection.enabled", true, true);
+      await config.update("connection.url", url, true);
+      await config.update("connection.database", "default", true);
+      await config.update("connection.username", "default", true);
+      await config.update("connection.password", "", true);
+
+      serverTree.connectedServer = server.name;
+      window.showInformationMessage(
+        `LSP connected to "${server.name}" at ${url}`,
+      );
+    }),
+
+    commands.registerCommand("clickhouse-analyzer.addToEnv", async (item) => {
+      const server: ctl.ServerInfo = item?.server;
+      if (!server || server.status !== "running") {
+        window.showErrorMessage("Server must be running to export connection details.");
+        return;
+      }
+
+      const wsRoot = getWorkspaceRoot();
+      if (!wsRoot) {
+        window.showErrorMessage("Open a folder first.");
+        return;
+      }
+
+      const envPath = path.join(wsRoot, ".env");
+      const vars: Record<string, string> = {
+        CLICKHOUSE_HOST: "localhost",
+        CLICKHOUSE_PORT: server.httpPort || "8123",
+        CLICKHOUSE_TCP_PORT: server.tcpPort || "9000",
+        CLICKHOUSE_URL: `http://localhost:${server.httpPort || "8123"}`,
+        CLICKHOUSE_USER: "default",
+        CLICKHOUSE_PASSWORD: "",
+        CLICKHOUSE_DB: "default",
+      };
+
+      // Read existing .env if it exists
+      let existing = "";
+      if (fs.existsSync(envPath)) {
+        existing = fs.readFileSync(envPath, "utf-8");
+      }
+
+      // Update or append each var
+      let updated = existing;
+      for (const [key, value] of Object.entries(vars)) {
+        const regex = new RegExp(`^${key}=.*$`, "m");
+        const line = `${key}=${value}`;
+        if (regex.test(updated)) {
+          updated = updated.replace(regex, line);
+        } else {
+          if (updated.length > 0 && !updated.endsWith("\n")) {
+            updated += os.EOL;
+          }
+          updated += line + os.EOL;
+        }
+      }
+
+      fs.writeFileSync(envPath, updated);
+
+      const doc = await workspace.openTextDocument(Uri.file(envPath));
+      await window.showTextDocument(doc);
+      window.showInformationMessage(
+        `ClickHouse connection details written to .env`,
+      );
+    }),
+  );
+}
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+/** Returns workspace root or shows an error and returns undefined. */
+function requireWorkspace(): string | undefined {
+  const root = getWorkspaceRoot();
+  if (!root) {
+    window.showErrorMessage("Open a folder first to manage local ClickHouse servers.");
+    return undefined;
+  }
+  if (!ctl.isInitialized(root)) {
+    window.showErrorMessage(
+      "ClickHouse is not initialized in this project. Run \"Initialize ClickHouse in Project\" first.",
+    );
+    return undefined;
+  }
+  return root;
+}
+
+async function ensureCtl(): Promise<boolean> {
+  const installed = await ctl.isCtlInstalled();
+  if (!installed) {
+    const choice = await window.showErrorMessage(
+      "clickhousectl is not installed. Install it to manage local servers.",
+      "Install",
+      "Cancel",
+    );
+    if (choice === "Install") {
+      commands.executeCommand("clickhouse-analyzer.installCtl");
+    }
+    return false;
+  }
+  return true;
+}
+
+async function disconnectLsp(): Promise<void> {
+  const config = workspace.getConfiguration("clickhouse-analyzer");
+  await config.update("connection.enabled", false, true);
 }
 
 function updateStatusBar() {

--- a/packages/vscode/src/sidebar.ts
+++ b/packages/vscode/src/sidebar.ts
@@ -1,0 +1,139 @@
+import * as vscode from "vscode";
+import * as ctl from "./ctl";
+
+// ── Server tree ──────────────────────────────────────────────────────
+
+export class ServerTreeProvider implements vscode.TreeDataProvider<ServerItem> {
+  private _onDidChangeTreeData = new vscode.EventEmitter<ServerItem | undefined>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  private servers: ctl.ServerInfo[] = [];
+  private _connectedServer: string | undefined;
+  private _workspaceRoot: string | undefined;
+
+  get connectedServer(): string | undefined {
+    return this._connectedServer;
+  }
+
+  set connectedServer(name: string | undefined) {
+    this._connectedServer = name;
+    this.refresh();
+  }
+
+  get workspaceRoot(): string | undefined {
+    return this._workspaceRoot;
+  }
+
+  set workspaceRoot(root: string | undefined) {
+    this._workspaceRoot = root;
+    this.servers = [];
+    this.refresh();
+  }
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire(undefined);
+  }
+
+  async reload(): Promise<void> {
+    if (!this._workspaceRoot) {
+      this.servers = [];
+    } else {
+      this.servers = await ctl.listServers(this._workspaceRoot);
+    }
+    this.refresh();
+  }
+
+  getTreeItem(element: ServerItem): vscode.TreeItem {
+    return element;
+  }
+
+  async getChildren(): Promise<ServerItem[]> {
+    if (!this._workspaceRoot) return [];
+
+    if (this.servers.length === 0) {
+      this.servers = await ctl.listServers(this._workspaceRoot);
+    }
+    return this.servers.map((s) => new ServerItem(s, s.name === this._connectedServer));
+  }
+}
+
+export class ServerItem extends vscode.TreeItem {
+  constructor(
+    public readonly server: ctl.ServerInfo,
+    public readonly isConnected: boolean,
+  ) {
+    super(server.name, vscode.TreeItemCollapsibleState.None);
+
+    const running = server.status === "running";
+    const icon = isConnected
+      ? new vscode.ThemeIcon("plug", new vscode.ThemeColor("charts.green"))
+      : running
+        ? new vscode.ThemeIcon("circle-filled", new vscode.ThemeColor("charts.green"))
+        : new vscode.ThemeIcon("circle-outline");
+
+    this.iconPath = icon;
+    this.contextValue = running ? "server-running" : "server-stopped";
+
+    const parts: string[] = [server.status];
+    if (running && server.httpPort) parts.push(`HTTP :${server.httpPort}`);
+    if (running && server.version) parts.push(`v${server.version}`);
+    if (isConnected) parts.push("(LSP connected)");
+    this.description = parts.join(" · ");
+
+    this.tooltip = [
+      `Server: ${server.name}`,
+      `Status: ${server.status}`,
+      server.httpPort ? `HTTP port: ${server.httpPort}` : null,
+      server.tcpPort ? `TCP port: ${server.tcpPort}` : null,
+      server.version ? `Version: ${server.version}` : null,
+      server.pid ? `PID: ${server.pid}` : null,
+      isConnected ? "\n✓ LSP is connected to this server" : null,
+    ]
+      .filter(Boolean)
+      .join("\n");
+  }
+}
+
+// ── Version tree ─────────────────────────────────────────────────────
+
+export class VersionTreeProvider implements vscode.TreeDataProvider<VersionItem> {
+  private _onDidChangeTreeData = new vscode.EventEmitter<VersionItem | undefined>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  private versions: ctl.VersionInfo[] = [];
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire(undefined);
+  }
+
+  async reload(): Promise<void> {
+    this.versions = await ctl.listVersions();
+    this.refresh();
+  }
+
+  getTreeItem(element: VersionItem): vscode.TreeItem {
+    return element;
+  }
+
+  async getChildren(): Promise<VersionItem[]> {
+    if (this.versions.length === 0) {
+      this.versions = await ctl.listVersions();
+    }
+    return this.versions.map((v) => new VersionItem(v));
+  }
+}
+
+export class VersionItem extends vscode.TreeItem {
+  constructor(public readonly info: ctl.VersionInfo) {
+    super(info.version, vscode.TreeItemCollapsibleState.None);
+
+    this.iconPath = info.active
+      ? new vscode.ThemeIcon("star-full", new vscode.ThemeColor("charts.yellow"))
+      : new vscode.ThemeIcon("package");
+
+    this.contextValue = info.active ? "version-active" : "version";
+    if (info.active) {
+      this.description = "(default)";
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a ClickHouse activity bar panel with sidebar for managing local ClickHouse servers via `clickhousectl` CLI
- **Local Servers** tree view: create, start, stop, delete servers scoped to the workspace, connect LSP to a running server, export connection details to `.env`
- **Installed Versions** tree view: install, remove, and set default ClickHouse versions (system-global)
- Workspace-aware: detects project initialization state, prompts to `chctl local init` when needed
- Uses `--json` output from chctl for reliable parsing
- ClickHouse logo SVG for activity bar icon and language file icon

## Test plan

- [ ] Open extension dev host (`code --extensionDevelopmentPath=packages/vscode`)
- [ ] Verify sidebar appears with ClickHouse logo in activity bar
- [ ] Test with no workspace open (should show "Open a folder" prompt)
- [ ] Test with workspace but no `.clickhouse` dir (should show "Initialize" prompt)
- [ ] Run init, create a server, verify it shows as running
- [ ] Click plug icon to connect LSP, verify status bar updates
- [ ] Click file-code icon to export `.env`, verify file contents
- [ ] Stop and delete server via context menu
- [ ] Install/remove ClickHouse versions, set default via star icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)