### PR TITLE
Gate `RwLock` import on lsp/codegen features

### DIFF
--- a/src/metadata/cache.rs
+++ b/src/metadata/cache.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+#[cfg(any(feature = "lsp", feature = "codegen"))]
 use tokio::sync::RwLock;
+#[cfg(not(any(feature = "lsp", feature = "codegen")))]
+use std::sync::RwLock;
 
 use super::generated;
 use super::types::*;


### PR DESCRIPTION
👋 Greetings from your friends at Grafana!

This patch came out of an experiment to consume `clickhouse-analyzer` as a WASM module in the ClickHouse Grafana datasource plugin (grafana/clickhouse-datasource#1780).

That PR wires up `@clickhouse/analyzer` as an experimental SQL validation engine for the Monaco editor, with `js-sql-parser` as a graceful fallback while the WASM initializes. The motivation is that ClickHouse SQL has syntax that PostgreSQL-biased parsers can't handle: `SETTINGS`, `FINAL,` array functions, etc., and the existing `pgsql-ast-parser` also silently lowercased all identifiers, corrupting round-trips for mixed-case names.

To make the WASM build work, `clickhouse-analyzer` needs to be buildable via `wasm-pack` without the `lsp` or `codegen` features. The problem was that `tokio::sync::RwLock` was imported unconditionally, and `tokio`'s async runtime isn't available in the WASM target, so the build failed. This PR fixes that by gating `RwLock` import on feature flags: use `tokio::sync::RwLock` when `lsp` or `codegen` features are active, fall back to `std::sync::RwLock` otherwise.