### PR TITLE
Regen package-lock.json

### DIFF
--- a/packages/clickhouse-analyzer/package-lock.json
+++ b/packages/clickhouse-analyzer/package-lock.json
@@ -1,13 +1,13 @@
 {
-    "name": "clickhouse-analyzer",
+    "name": "@clickhouse/analyzer",
     "version": "0.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "clickhouse-analyzer",
+            "name": "@clickhouse/analyzer",
             "version": "0.1.0",
-            "license": "MIT",
+            "license": "Apache-2.0",
             "devDependencies": {
                 "@types/node": "^25.5.0",
                 "typescript": "^5.4.0"


### PR DESCRIPTION
Regenerates `package-lock.json` with the correct package name, which gets `npm link` working.