### PR TITLE
Feat/lsp fixes

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.87.0"
-components = ["rustfmt"]
+components = ["rustfmt", "clippy"]

--- a/src/analysis/cursor_context.rs
+++ b/src/analysis/cursor_context.rs
@@ -103,7 +103,11 @@ fn token_before_impl<'a>(
                 if token.kind == SyntaxKind::Whitespace || token.kind == SyntaxKind::Comment {
                     continue;
                 }
-                if token.start <= offset {
+                // A token is "before" the cursor only if it has fully ended by
+                // the cursor position. Using start <= offset would pick up a
+                // token that merely begins at the cursor (e.g. the `FROM` in
+                // `SELECT t.|FROM t` where the user wants dot-access).
+                if token.end <= offset {
                     *best = Some((token.text(source), parent_kind));
                 }
             }
@@ -377,7 +381,10 @@ fn find_ident_before_dot_impl<'a>(
                 if token.kind == SyntaxKind::Whitespace || token.kind == SyntaxKind::Comment {
                     continue;
                 }
-                if token.start > offset {
+                // Only consider tokens that fully ended before the cursor.
+                // This matters when the user typed `t.|word` with no space:
+                // `word` starts at the cursor, but we want `.` as `prev`.
+                if token.end > offset {
                     return;
                 }
                 *prev_prev = *prev;

--- a/src/analysis/scope.rs
+++ b/src/analysis/scope.rs
@@ -20,6 +20,15 @@ pub struct TableRef {
     pub range: (u32, u32),
 }
 
+/// A subquery used in a FROM position, together with its alias and the
+/// list of column names produced by its top-level projection. Gives the
+/// completion engine something to show when the user writes `alias.`.
+#[derive(Debug, Clone)]
+pub struct SubqueryRef {
+    pub alias: String,
+    pub columns: Vec<String>,
+}
+
 /// Resolved names within a single query.
 #[derive(Debug, Clone, Default)]
 pub struct QueryScope {
@@ -27,6 +36,17 @@ pub struct QueryScope {
     pub table_aliases: Vec<NameBinding>,
     pub column_aliases: Vec<NameBinding>,
     pub table_refs: Vec<TableRef>,
+    pub subquery_refs: Vec<SubqueryRef>,
+}
+
+impl QueryScope {
+    /// Columns produced by a subquery with the given alias, case-insensitive.
+    pub fn subquery_columns_for(&self, alias: &str) -> Option<Vec<String>> {
+        self.subquery_refs
+            .iter()
+            .find(|s| s.alias.eq_ignore_ascii_case(alias))
+            .map(|s| s.columns.clone())
+    }
 }
 
 /// Build a scope from the CST of a statement.
@@ -122,41 +142,59 @@ fn extract_cte(tree: &SyntaxTree, source: &str) -> Option<NameBinding> {
 /// CST structure: FromClause contains TableIdentifier and TableAlias as siblings.
 fn collect_table_refs(tree: &SyntaxTree, source: &str, scope: &mut QueryScope) {
     let mut last_table_ref: Option<TableRef> = None;
+    // Track the most recent subquery in the FROM position so a trailing
+    // TableAlias can be attached to it as a SubqueryRef.
+    let mut last_subquery_projection: Option<Vec<String>> = None;
 
     for child in &tree.children {
         if let SyntaxChild::Tree(subtree) = child {
             match subtree.kind {
                 SyntaxKind::TableIdentifier => {
-                    // Flush previous table ref before starting a new one
                     if let Some(tref) = last_table_ref.take() {
                         scope.table_refs.push(tref);
                     }
+                    last_subquery_projection = None;
                     last_table_ref = extract_table_identifier(subtree, source);
                 }
                 SyntaxKind::TableAlias => {
-                    // Attach alias to the most recent table ref
-                    if let Some(ref mut tref) = last_table_ref {
-                        if let Some((alias_name, alias_token)) =
-                            extract_alias_name(subtree, source)
-                        {
+                    if let Some((alias_name, alias_token)) =
+                        extract_alias_name(subtree, source)
+                    {
+                        if let Some(ref mut tref) = last_table_ref {
                             tref.alias = Some(alias_name.clone());
                             scope.table_aliases.push(NameBinding {
                                 name: alias_name,
                                 range: (alias_token.start, alias_token.end),
                                 definition_range: (subtree.start, subtree.end),
                             });
+                        } else if let Some(cols) = last_subquery_projection.take() {
+                            scope.table_aliases.push(NameBinding {
+                                name: alias_name.clone(),
+                                range: (alias_token.start, alias_token.end),
+                                definition_range: (subtree.start, subtree.end),
+                            });
+                            scope.subquery_refs.push(SubqueryRef {
+                                alias: alias_name,
+                                columns: cols,
+                            });
                         }
                     }
                 }
+                SyntaxKind::SubqueryExpression => {
+                    // Record the subquery's projection so a following alias
+                    // can claim it. The subquery's own FROM is intentionally
+                    // NOT added to the outer scope.
+                    last_subquery_projection =
+                        Some(extract_subquery_projection(subtree, source));
+                }
                 SyntaxKind::TableExpression => {
-                    // Recurse into table expressions
                     collect_table_refs(subtree, source, scope);
                 }
                 SyntaxKind::JoinClause => {
-                    // Flush before recursing into JOIN
                     if let Some(tref) = last_table_ref.take() {
                         scope.table_refs.push(tref);
                     }
+                    last_subquery_projection = None;
                     collect_table_refs(subtree, source, scope);
                 }
                 _ => {}
@@ -164,10 +202,108 @@ fn collect_table_refs(tree: &SyntaxTree, source: &str, scope: &mut QueryScope) {
         }
     }
 
-    // Flush the last table ref
     if let Some(tref) = last_table_ref {
         scope.table_refs.push(tref);
     }
+}
+
+/// Extract the top-level projection column names from a SubqueryExpression.
+/// Returns the AS-alias where present, otherwise the last segment of a
+/// dotted column reference, otherwise a synthetic name like `col_1`.
+fn extract_subquery_projection(tree: &SyntaxTree, source: &str) -> Vec<String> {
+    let Some(select_clause) = find_child(tree, SyntaxKind::SelectClause)
+        .or_else(|| find_descendant_select_clause(tree))
+    else {
+        return Vec::new();
+    };
+    let Some(column_list) = find_child(select_clause, SyntaxKind::ColumnList) else {
+        return Vec::new();
+    };
+
+    let mut out = Vec::new();
+    let mut pending_expr_name: Option<String> = None;
+    let mut index = 0usize;
+
+    for child in &column_list.children {
+        match child {
+            SyntaxChild::Tree(sub) => {
+                if sub.kind == SyntaxKind::ColumnAlias {
+                    if let Some((name, _)) = extract_alias_name(sub, source) {
+                        out.push(name);
+                        pending_expr_name = None;
+                        index += 1;
+                    }
+                } else {
+                    if let Some(prev) = pending_expr_name.take() {
+                        out.push(prev);
+                        index += 1;
+                    }
+                    pending_expr_name = Some(
+                        last_identifier_in(sub, source)
+                            .unwrap_or_else(|| format!("col_{}", index + 1)),
+                    );
+                }
+            }
+            SyntaxChild::Token(tok) => {
+                if tok.kind == SyntaxKind::Comma {
+                    if let Some(prev) = pending_expr_name.take() {
+                        out.push(prev);
+                        index += 1;
+                    }
+                }
+            }
+        }
+    }
+    if let Some(prev) = pending_expr_name {
+        out.push(prev);
+    }
+    out
+}
+
+fn find_child<'a>(tree: &'a SyntaxTree, kind: SyntaxKind) -> Option<&'a SyntaxTree> {
+    tree.children.iter().find_map(|c| match c {
+        SyntaxChild::Tree(t) if t.kind == kind => Some(t),
+        _ => None,
+    })
+}
+
+fn find_descendant_select_clause(tree: &SyntaxTree) -> Option<&SyntaxTree> {
+    for child in &tree.children {
+        if let SyntaxChild::Tree(t) = child {
+            if t.kind == SyntaxKind::SelectClause {
+                return Some(t);
+            }
+            if let Some(found) = find_descendant_select_clause(t) {
+                return Some(found);
+            }
+        }
+    }
+    None
+}
+
+/// Walk the rightmost identifier-bearing path of an expression subtree to
+/// guess the column name it would produce (e.g. `t.col` → `col`).
+fn last_identifier_in(tree: &SyntaxTree, source: &str) -> Option<String> {
+    let mut last: Option<String> = None;
+    for child in &tree.children {
+        match child {
+            SyntaxChild::Token(tok) => {
+                if tok.kind == SyntaxKind::BareWord || tok.kind == SyntaxKind::QuotedIdentifier {
+                    let text = tok.text(source);
+                    if text.eq_ignore_ascii_case("AS") {
+                        continue;
+                    }
+                    last = Some(unquote(text).to_string());
+                }
+            }
+            SyntaxChild::Tree(sub) => {
+                if let Some(inner) = last_identifier_in(sub, source) {
+                    last = Some(inner);
+                }
+            }
+        }
+    }
+    last
 }
 
 /// Extract the alias name from a TableAlias or ColumnAlias node.

--- a/src/diagnostics/bracket_matching.rs
+++ b/src/diagnostics/bracket_matching.rs
@@ -25,12 +25,12 @@ fn collect_brackets(tree: &SyntaxTree, stack: &mut Vec<BracketInfo>) {
                     | SyntaxKind::ClosingCurlyBrace => {
                         // Pop matching opener
                         if let Some(last) = stack.last() {
-                            let matches = match (last.kind, token.kind) {
-                                (SyntaxKind::OpeningRoundBracket, SyntaxKind::ClosingRoundBracket) => true,
-                                (SyntaxKind::OpeningSquareBracket, SyntaxKind::ClosingSquareBracket) => true,
-                                (SyntaxKind::OpeningCurlyBrace, SyntaxKind::ClosingCurlyBrace) => true,
-                                _ => false,
-                            };
+                            let matches = matches!(
+                                (last.kind, token.kind),
+                                (SyntaxKind::OpeningRoundBracket, SyntaxKind::ClosingRoundBracket)
+                                    | (SyntaxKind::OpeningSquareBracket, SyntaxKind::ClosingSquareBracket)
+                                    | (SyntaxKind::OpeningCurlyBrace, SyntaxKind::ClosingCurlyBrace)
+                            );
                             if matches {
                                 stack.pop();
                             }

--- a/src/formatter/context.rs
+++ b/src/formatter/context.rs
@@ -12,6 +12,10 @@ pub struct FormatterContext<'a> {
     pending_newline: bool,
     /// Set when skipped whitespace contained a blank line (2+ newlines).
     pending_blank_line: bool,
+    /// >0 when emitting tokens inside an identifier-bearing node (table name,
+    /// column reference, etc.). A BareWord emitted in this region must never
+    /// be re-cased as a keyword, even if its text matches one.
+    identifier_depth: usize,
 }
 
 impl<'a> FormatterContext<'a> {
@@ -25,7 +29,20 @@ impl<'a> FormatterContext<'a> {
             needs_space: false,
             pending_newline: false,
             pending_blank_line: false,
+            identifier_depth: 0,
         }
+    }
+
+    pub fn enter_identifier(&mut self) {
+        self.identifier_depth += 1;
+    }
+
+    pub fn exit_identifier(&mut self) {
+        self.identifier_depth = self.identifier_depth.saturating_sub(1);
+    }
+
+    pub fn in_identifier(&self) -> bool {
+        self.identifier_depth > 0
     }
 
     pub fn write_newline(&mut self) {
@@ -113,6 +130,7 @@ impl<'a> FormatterContext<'a> {
             needs_space: false,
             pending_newline: false,
             pending_blank_line: false,
+            identifier_depth: self.identifier_depth,
         }
     }
 

--- a/src/formatter/context.rs
+++ b/src/formatter/context.rs
@@ -12,9 +12,9 @@ pub struct FormatterContext<'a> {
     pending_newline: bool,
     /// Set when skipped whitespace contained a blank line (2+ newlines).
     pending_blank_line: bool,
-    /// >0 when emitting tokens inside an identifier-bearing node (table name,
-    /// column reference, etc.). A BareWord emitted in this region must never
-    /// be re-cased as a keyword, even if its text matches one.
+    /// Greater than 0 when emitting tokens inside an identifier-bearing node
+    /// (table name, column reference, etc.). A BareWord emitted in this region
+    /// must never be re-cased as a keyword, even if its text matches one.
     identifier_depth: usize,
 }
 

--- a/src/formatter/format_node.rs
+++ b/src/formatter/format_node.rs
@@ -1621,11 +1621,10 @@ fn format_column_def_list(tree: &SyntaxTree, ctx: &mut FormatterContext) {
         let content = if let Some(ref c) = comment {
             // Strip the comment from the formatted content
             let trimmed = formatted.trim_end();
-            let content = trimmed.strip_suffix(c.as_str())
+            trimmed.strip_suffix(c.as_str())
                 .unwrap_or(trimmed)
                 .trim_end()
-                .to_string();
-            content
+                .to_string()
         } else {
             formatted.trim_end().to_string()
         };

--- a/src/formatter/format_node.rs
+++ b/src/formatter/format_node.rs
@@ -149,8 +149,8 @@ pub fn format_node(tree: &SyntaxTree, ctx: &mut FormatterContext) {
         SyntaxKind::WhenClause => format_when_clause(tree, ctx),
         SyntaxKind::SubqueryExpression => format_subquery(tree, ctx),
         SyntaxKind::CastExpression => format_inline(tree, ctx),
-        SyntaxKind::ColumnAlias => format_inline(tree, ctx),
-        SyntaxKind::TableAlias => format_inline(tree, ctx),
+        SyntaxKind::ColumnAlias => format_alias(tree, ctx),
+        SyntaxKind::TableAlias => format_alias(tree, ctx),
         SyntaxKind::OrderByItem => format_inline(tree, ctx),
         SyntaxKind::SettingItem => format_inline(tree, ctx),
         SyntaxKind::WithExpressionItem => format_inline(tree, ctx),
@@ -165,11 +165,11 @@ pub fn format_node(tree: &SyntaxTree, ctx: &mut FormatterContext) {
         SyntaxKind::ArrayAccessExpression => format_inline_no_spaces(tree, ctx),
         SyntaxKind::MapExpression => format_brace_list(tree, ctx),
         SyntaxKind::QueryParameterExpression => format_inline_no_spaces(tree, ctx),
-        SyntaxKind::TableIdentifier => format_inline(tree, ctx),
+        SyntaxKind::TableIdentifier => format_identifier_inline(tree, ctx),
         SyntaxKind::TableExpression => format_inline(tree, ctx),
         SyntaxKind::TableFunction => format_function_call(tree, ctx),
-        SyntaxKind::QualifiedName => format_inline_no_spaces(tree, ctx),
-        SyntaxKind::ColumnReference => format_inline(tree, ctx),
+        SyntaxKind::QualifiedName => format_identifier_inline_no_spaces(tree, ctx),
+        SyntaxKind::ColumnReference => format_identifier_inline(tree, ctx),
         SyntaxKind::DataType => format_data_type(tree, ctx),
         SyntaxKind::DataTypeParameters => format_data_type(tree, ctx),
         SyntaxKind::UsingList => format_inline(tree, ctx),
@@ -1261,6 +1261,71 @@ fn format_inline_no_spaces(tree: &SyntaxTree, ctx: &mut FormatterContext) {
     }
 }
 
+/// Wrap format_inline with identifier-context so BareWords matching keywords
+/// (e.g. a column literally named `type`) are not re-cased.
+fn format_identifier_inline(tree: &SyntaxTree, ctx: &mut FormatterContext) {
+    ctx.enter_identifier();
+    format_inline(tree, ctx);
+    ctx.exit_identifier();
+}
+
+/// Wrap format_inline_no_spaces with identifier-context for qualified names.
+fn format_identifier_inline_no_spaces(tree: &SyntaxTree, ctx: &mut FormatterContext) {
+    ctx.enter_identifier();
+    format_inline_no_spaces(tree, ctx);
+    ctx.exit_identifier();
+}
+
+/// Format a TableAlias or ColumnAlias: the optional `AS` is a keyword, the
+/// alias name itself is an identifier and must keep its source case.
+fn format_alias(tree: &SyntaxTree, ctx: &mut FormatterContext) {
+    let mut prev_kind: Option<SyntaxKind> = None;
+    let mut seen_as = false;
+    for child in &tree.children {
+        match child {
+            SyntaxChild::Token(t) if t.kind == SyntaxKind::Whitespace => {
+                ctx.note_skipped_whitespace(t.text(ctx.source));
+            }
+            SyntaxChild::Token(t) if t.kind == SyntaxKind::Comment => {
+                emit_comment(t, ctx);
+            }
+            SyntaxChild::Token(t) => {
+                if !no_space_before(t) {
+                    if let Some(pk) = prev_kind {
+                        if !no_space_after(pk) {
+                            ctx.write_space();
+                        }
+                    }
+                }
+                let is_as_kw = t.kind == SyntaxKind::BareWord
+                    && !seen_as
+                    && t.text(ctx.source).eq_ignore_ascii_case("AS");
+                if is_as_kw {
+                    emit_token(t, ctx);
+                    seen_as = true;
+                } else if t.kind == SyntaxKind::BareWord {
+                    // Alias name — always preserve case.
+                    ctx.enter_identifier();
+                    emit_token(t, ctx);
+                    ctx.exit_identifier();
+                } else {
+                    emit_token(t, ctx);
+                }
+                prev_kind = Some(t.kind);
+            }
+            SyntaxChild::Tree(subtree) => {
+                if let Some(pk) = prev_kind {
+                    if !no_space_after(pk) {
+                        ctx.write_space();
+                    }
+                }
+                format_node(subtree, ctx);
+                prev_kind = Some(SyntaxKind::BareWord);
+            }
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Passthrough -- resilience backstop
 // ---------------------------------------------------------------------------
@@ -1315,7 +1380,13 @@ fn emit_token(token: &Token, ctx: &mut FormatterContext) {
     if token.kind == SyntaxKind::Whitespace {
         return;
     }
-    if token.kind == SyntaxKind::BareWord && is_keyword(token.text(ctx.source)) && !is_value_keyword(token.text(ctx.source)) {
+    // Preserve case for identifiers — a BareWord inside an identifier-bearing
+    // node (e.g. a table named `type`) must not be rewritten as a keyword.
+    if token.kind == SyntaxKind::BareWord
+        && !ctx.in_identifier()
+        && is_keyword(token.text(ctx.source))
+        && !is_value_keyword(token.text(ctx.source))
+    {
         ctx.write_keyword(token.text(ctx.source));
     } else {
         ctx.write_token(token.text(ctx.source));

--- a/src/lsp/completion.rs
+++ b/src/lsp/completion.rs
@@ -1,11 +1,19 @@
 use tower_lsp::lsp_types::*;
 
 use crate::analysis::cursor_context::{cursor_context, CursorContext};
-use crate::analysis::scope::build_scope;
+use crate::analysis::scope::{build_scope, find_enclosing_statement, QueryScope};
 use crate::metadata::cache::SharedMetadata;
 use crate::parser::diagnostic::Parse;
 
 use super::line_index::LineIndex;
+
+/// Build the scope for the statement enclosing the cursor. When the cursor is
+/// inside a subquery, this gives us the *inner* scope so column completions
+/// are resolved against the subquery's own FROM clause, not the outer query.
+fn scope_at(parse: &Parse, offset: u32) -> QueryScope {
+    let stmt = find_enclosing_statement(&parse.tree, offset).unwrap_or(&parse.tree);
+    build_scope(stmt, &parse.source)
+}
 
 pub async fn handle_completion(
     parse: &Parse,
@@ -34,10 +42,14 @@ pub async fn handle_completion(
         CursorContext::ColumnOfTable { qualifier } => {
             let mut meta = metadata.write().await;
             if meta.is_connected() {
-                let scope = build_scope(&parse.tree, &parse.source);
-                let default_db = meta.default_database().to_string();
-                if let Some((db, table)) = resolve_qualifier(qualifier, &scope, &default_db) {
-                    let _ = meta.ensure_columns(&db, &table).await;
+                let scope = scope_at(parse, offset);
+                // Subquery aliases resolve to their own projection — no
+                // server lookup needed. Only pre-fetch for real tables.
+                if scope.subquery_columns_for(qualifier).is_none() {
+                    let default_db = meta.default_database().to_string();
+                    if let Some((db, table)) = resolve_qualifier(qualifier, &scope, &default_db) {
+                        let _ = meta.ensure_columns(&db, &table).await;
+                    }
                 }
             }
         }
@@ -45,7 +57,7 @@ pub async fn handle_completion(
             // Pre-fetch columns for all tables in scope
             let mut meta = metadata.write().await;
             if meta.is_connected() {
-                let scope = build_scope(&parse.tree, &parse.source);
+                let scope = scope_at(parse, offset);
                 let default_db = meta.default_database().to_string();
                 for tref in &scope.table_refs {
                     let db = tref.database.as_deref().unwrap_or(&default_db);
@@ -100,28 +112,40 @@ pub async fn handle_completion(
         }
 
         CursorContext::ColumnOfTable { ref qualifier } => {
-            // Resolve qualifier to database.table via scope, then show columns
-            let scope = build_scope(&parse.tree, &parse.source);
-            let default_db = meta.default_database().to_string();
-            if let Some((db, table)) = resolve_qualifier(qualifier, &scope, &default_db) {
-                for col in meta.get_columns(&db, &table) {
+            let scope = scope_at(parse, offset);
+            // Subquery alias: expose the subquery's own projection directly.
+            if let Some(cols) = scope.subquery_columns_for(qualifier) {
+                for name in cols {
                     items.push(CompletionItem {
-                        label: col.name.clone(),
+                        label: name,
                         kind: Some(CompletionItemKind::FIELD),
-                        detail: Some(col.data_type.clone()),
-                        documentation: if col.comment.is_empty() {
-                            None
-                        } else {
-                            Some(Documentation::String(col.comment.clone()))
-                        },
+                        detail: Some("subquery projection".into()),
                         ..Default::default()
                     });
+                }
+            } else {
+                // Regular table or table alias — resolve and look up metadata.
+                let default_db = meta.default_database().to_string();
+                if let Some((db, table)) = resolve_qualifier(qualifier, &scope, &default_db) {
+                    for col in meta.get_columns(&db, &table) {
+                        items.push(CompletionItem {
+                            label: col.name.clone(),
+                            kind: Some(CompletionItemKind::FIELD),
+                            detail: Some(col.data_type.clone()),
+                            documentation: if col.comment.is_empty() {
+                                None
+                            } else {
+                                Some(Documentation::String(col.comment.clone()))
+                            },
+                            ..Default::default()
+                        });
+                    }
                 }
             }
         }
 
         CursorContext::SelectExpression => {
-            add_columns_in_scope(&meta, parse, &mut items);
+            add_columns_in_scope(&meta, parse, offset, &mut items);
             add_functions(&meta.functions, &mut items);
             for kw in &["DISTINCT", "CASE", "NOT", "NULL", "TRUE", "FALSE", "*"] {
                 items.push(keyword_item(kw));
@@ -137,7 +161,7 @@ pub async fn handle_completion(
         }
 
         CursorContext::Expression => {
-            add_columns_in_scope(&meta, parse, &mut items);
+            add_columns_in_scope(&meta, parse, offset, &mut items);
             add_functions(&meta.functions, &mut items);
             for kw in &[
                 "AND", "OR", "NOT", "IN", "BETWEEN", "LIKE", "ILIKE", "IS",
@@ -158,7 +182,7 @@ pub async fn handle_completion(
             // Only show completions if the user has started typing a prefix
             // Otherwise signature help is more useful here
             if !lower_prefix.is_empty() {
-                add_columns_in_scope(&meta, parse, &mut items);
+                add_columns_in_scope(&meta, parse, offset, &mut items);
                 add_functions(&meta.functions, &mut items);
             }
         }
@@ -301,12 +325,13 @@ pub async fn handle_completion(
 fn add_columns_in_scope(
     meta: &crate::metadata::cache::MetadataCache,
     parse: &Parse,
+    offset: u32,
     items: &mut Vec<CompletionItem>,
 ) {
     if !meta.is_connected() {
         return;
     }
-    let scope = build_scope(&parse.tree, &parse.source);
+    let scope = scope_at(parse, offset);
     let default_db = meta.default_database().to_string();
     let mut seen = std::collections::HashSet::new();
 
@@ -492,7 +517,7 @@ mod tests {
     fn resolve_at(sql: &str, cursor: usize) -> Option<(String, String)> {
         use crate::analysis::cursor_context::{cursor_context, CursorContext};
         let parse = parser::parse(sql);
-        let scope = build_scope(&parse.tree, &parse.source);
+        let scope = scope_at(&parse, cursor as u32);
         let ctx = cursor_context(&parse.tree, &parse.source, cursor as u32);
         match ctx {
             CursorContext::ColumnOfTable { qualifier } => {
@@ -569,6 +594,55 @@ mod tests {
             resolve_at(sql, cursor),
             Some(("default".into(), "mytable".into())),
         );
+    }
+
+    #[test]
+    fn e2e_cursor_inside_subquery_uses_inner_scope() {
+        // Cursor is inside a subquery; the inner `FROM inner_tbl` must be
+        // what defines the scope, not the outer query.
+        let sql = "SELECT * FROM (SELECT x. FROM inner_tbl AS x) outer_alias";
+        let cursor = sql.find("x. ").unwrap() + 2;
+        assert_eq!(
+            resolve_at(sql, cursor),
+            Some(("default".into(), "inner_tbl".into())),
+        );
+    }
+
+    #[test]
+    fn e2e_subquery_alias_exposes_projection() {
+        // Outer query references a subquery via its alias; the subquery's
+        // projected columns (`a`, `b`) should be resolvable through the alias.
+        let sql = "SELECT x. FROM (SELECT a, b FROM inner_tbl) x";
+        let parse = parser::parse(sql);
+        let scope = scope_at(&parse, (sql.find("x. ").unwrap() + 2) as u32);
+        // The subquery alias `x` should expose `a` and `b` as columns.
+        let cols = scope.subquery_columns_for("x");
+        assert_eq!(
+            cols,
+            Some(vec!["a".to_string(), "b".to_string()])
+        );
+    }
+
+    #[test]
+    fn e2e_subquery_alias_exposes_as_aliased_projection() {
+        // Inner columns via expression + AS alias — should surface the alias.
+        let sql = "SELECT x. FROM (SELECT count() AS total, user_id FROM t GROUP BY user_id) x";
+        let parse = parser::parse(sql);
+        let scope = scope_at(&parse, (sql.find("x. ").unwrap() + 2) as u32);
+        let cols = scope.subquery_columns_for("x");
+        assert_eq!(
+            cols,
+            Some(vec!["total".to_string(), "user_id".to_string()])
+        );
+    }
+
+    #[test]
+    fn e2e_subquery_alias_does_not_match_regular_table() {
+        // Regular alias (not a subquery) returns None for subquery_columns_for.
+        let sql = "SELECT x. FROM mytable AS x";
+        let parse = parser::parse(sql);
+        let scope = scope_at(&parse, (sql.find("x. ").unwrap() + 2) as u32);
+        assert!(scope.subquery_columns_for("x").is_none());
     }
 
     #[test]

--- a/src/lsp/completion.rs
+++ b/src/lsp/completion.rs
@@ -422,3 +422,164 @@ fn resolve_qualifier(
     // Fallback: treat qualifier as a table name in the default database
     Some((default_db.to_string(), qualifier.to_string()))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analysis::scope::build_scope;
+    use crate::parser;
+
+    fn scope_for(sql: &str) -> crate::analysis::scope::QueryScope {
+        let parse = parser::parse(sql);
+        build_scope(&parse.tree, &parse.source)
+    }
+
+    #[test]
+    fn resolve_table_alias() {
+        let scope = scope_for("SELECT t.a FROM mytable AS t");
+        let resolved = resolve_qualifier("t", &scope, "default");
+        assert_eq!(resolved, Some(("default".into(), "mytable".into())));
+    }
+
+    #[test]
+    fn resolve_table_alias_case_insensitive() {
+        let scope = scope_for("SELECT T.a FROM mytable AS t");
+        let resolved = resolve_qualifier("T", &scope, "default");
+        assert_eq!(resolved, Some(("default".into(), "mytable".into())));
+    }
+
+    #[test]
+    fn resolve_table_name() {
+        let scope = scope_for("SELECT mytable.a FROM mytable");
+        let resolved = resolve_qualifier("mytable", &scope, "default");
+        assert_eq!(resolved, Some(("default".into(), "mytable".into())));
+    }
+
+    #[test]
+    fn resolve_qualified_table_via_last_segment() {
+        // `SELECT db.t.col FROM db.t` — the qualifier extracted at the
+        // cursor is the last segment before the dot, which is `t`.
+        // It should resolve to the fully-qualified ref.
+        let scope = scope_for("SELECT db.t.a FROM db.t");
+        let resolved = resolve_qualifier("t", &scope, "default");
+        assert_eq!(resolved, Some(("db".into(), "t".into())));
+    }
+
+    #[test]
+    fn resolve_alias_on_qualified_table() {
+        let scope = scope_for("SELECT a.col FROM db.mytable AS a");
+        let resolved = resolve_qualifier("a", &scope, "default");
+        assert_eq!(resolved, Some(("db".into(), "mytable".into())));
+    }
+
+    #[test]
+    fn resolve_in_join() {
+        let scope = scope_for(
+            "SELECT a.x, b.y FROM users AS a JOIN orders AS b ON a.id = b.user_id",
+        );
+        assert_eq!(
+            resolve_qualifier("a", &scope, "default"),
+            Some(("default".into(), "users".into()))
+        );
+        assert_eq!(
+            resolve_qualifier("b", &scope, "default"),
+            Some(("default".into(), "orders".into()))
+        );
+    }
+
+    /// End-to-end: given a SQL string and cursor offset, return the resolved
+    /// (database, table) pair the completion engine would look up columns in.
+    fn resolve_at(sql: &str, cursor: usize) -> Option<(String, String)> {
+        use crate::analysis::cursor_context::{cursor_context, CursorContext};
+        let parse = parser::parse(sql);
+        let scope = build_scope(&parse.tree, &parse.source);
+        let ctx = cursor_context(&parse.tree, &parse.source, cursor as u32);
+        match ctx {
+            CursorContext::ColumnOfTable { qualifier } => {
+                resolve_qualifier(&qualifier, &scope, "default")
+            }
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn e2e_alias_after_dot_resolves() {
+        // Cursor at `|` after `t.` in SELECT.
+        let sql = "SELECT t. FROM mytable AS t";
+        let cursor = sql.find('.').unwrap() + 1;
+        assert_eq!(
+            resolve_at(sql, cursor),
+            Some(("default".into(), "mytable".into()))
+        );
+    }
+
+    #[test]
+    fn e2e_qualified_table_after_dot_resolves() {
+        // Cursor at `|` after `t.` (last dot) in `SELECT db.t.| FROM db.t`.
+        let sql = "SELECT db.t. FROM db.t";
+        let cursor = sql.rfind("t. FROM").unwrap() + 2;
+        assert_eq!(
+            resolve_at(sql, cursor),
+            Some(("db".into(), "t".into()))
+        );
+    }
+
+    #[test]
+    fn e2e_alias_resolves_when_select_is_malformed() {
+        // User is mid-edit: SELECT clause has extra junk, FROM still parseable.
+        // The resolver should still see the alias and resolve to the table.
+        let sql = "SELECT x, a. FROM mytable AS a";
+        let cursor = sql.find("a. FROM").unwrap() + 2;
+        assert_eq!(
+            resolve_at(sql, cursor),
+            Some(("default".into(), "mytable".into())),
+            "scope should still find alias 'a' when SELECT is mid-edit"
+        );
+    }
+
+    #[test]
+    fn e2e_qualified_table_in_where_resolves() {
+        let sql = "SELECT * FROM db.mytable WHERE mytable. = 1";
+        let cursor = sql.find("mytable. =").unwrap() + "mytable.".len();
+        assert_eq!(
+            resolve_at(sql, cursor),
+            Some(("db".into(), "mytable".into()))
+        );
+    }
+
+    #[test]
+    fn e2e_dot_at_end_of_partial_query_resolves() {
+        // Cursor right at the end of a partial query. No trailing token at all.
+        let sql = "SELECT t. FROM mytable AS t";
+        let cursor = sql.find('.').unwrap() + 1;
+        assert_eq!(
+            resolve_at(sql, cursor),
+            Some(("default".into(), "mytable".into()))
+        );
+    }
+
+    #[test]
+    #[ignore = "requires SELECT-clause recovery to not consume FROM into qualified column"]
+    fn e2e_dot_cursor_with_no_space_before_from() {
+        // Typical live typing: user hit `.` and autocomplete fires before
+        // any trailing character is typed. The adjacent `FROM` is currently
+        // consumed as a column name, losing the FROM clause.
+        let sql = "SELECT t.FROM mytable AS t";
+        let cursor = sql.find('.').unwrap() + 1;
+        assert_eq!(
+            resolve_at(sql, cursor),
+            Some(("default".into(), "mytable".into())),
+        );
+    }
+
+    #[test]
+    fn e2e_alias_dot_works_across_multiple_columns() {
+        // Real-world: cursor on `b.` after some columns already typed.
+        let sql = "SELECT a.x, a.y, b. FROM users AS a JOIN orders AS b ON a.id = b.id";
+        let cursor = sql.find("b. ").unwrap() + 2;
+        assert_eq!(
+            resolve_at(sql, cursor),
+            Some(("default".into(), "orders".into()))
+        );
+    }
+}

--- a/src/lsp/completion.rs
+++ b/src/lsp/completion.rs
@@ -559,11 +559,10 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "requires SELECT-clause recovery to not consume FROM into qualified column"]
     fn e2e_dot_cursor_with_no_space_before_from() {
-        // Typical live typing: user hit `.` and autocomplete fires before
-        // any trailing character is typed. The adjacent `FROM` is currently
-        // consumed as a column name, losing the FROM clause.
+        // Live typing: user just hit `.` and autocomplete fires before any
+        // trailing character. The adjacent `FROM` must not be consumed into
+        // the qualified column reference.
         let sql = "SELECT t.FROM mytable AS t";
         let cursor = sql.find('.').unwrap() + 1;
         assert_eq!(

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -146,18 +146,19 @@ impl Backend {
                         _ => continue,
                     };
 
-                    let stmt_text = &parse.source[subtree.start as usize..subtree.end as usize];
-                    let trimmed = stmt_text.trim();
-                    if trimmed.is_empty() {
+                    // EXPLAIN PLAN only accepts SELECT (and UNION of SELECTs).
+                    // Running it against INSERT/CREATE/ALTER/etc. produces a
+                    // server-side error that isn't useful to the user.
+                    if !matches!(
+                        subtree.kind,
+                        SyntaxKind::SelectStatement | SyntaxKind::UnionClause
+                    ) {
                         continue;
                     }
 
-                    // Skip non-query statements that EXPLAIN PLAN can't handle
-                    let upper = trimmed.to_uppercase();
-                    if !upper.starts_with("SELECT")
-                        && !upper.starts_with("WITH")
-                        && !upper.starts_with("INSERT")
-                    {
+                    let stmt_text = &parse.source[subtree.start as usize..subtree.end as usize];
+                    let trimmed = stmt_text.trim();
+                    if trimmed.is_empty() {
                         continue;
                     }
 

--- a/src/parser/grammar/create_table.rs
+++ b/src/parser/grammar/create_table.rs
@@ -87,6 +87,26 @@ fn parse_create_table(p: &mut Parser) {
     // ON CLUSTER
     common::parse_on_cluster(p);
 
+    // CLONE AS [db.]source_table — copies the source table's schema and data
+    // into the new table. ClickHouse optionally accepts ENGINE/ORDER BY/etc.
+    // overrides after, so fall through to the standard clause handling.
+    if p.at_keyword(Keyword::Clone) {
+        let cm = p.start();
+        p.advance(); // consume CLONE
+        p.expect_keyword(Keyword::As);
+        common::parse_table_identifier(p);
+        p.complete(cm, SyntaxKind::AsClause);
+
+        common::skip_to_keywords(p, CREATE_TABLE_KEYWORDS);
+        if p.at_keyword(Keyword::Engine) {
+            parse_engine_clause(p);
+        }
+        common::skip_to_keywords(p, CREATE_TABLE_KEYWORDS);
+        parse_table_clauses(p);
+        p.complete(m, SyntaxKind::TableDefinition);
+        return;
+    }
+
     // UUID (optional, skip string literal)
     if p.at_keyword(Keyword::As) && !p.at(SyntaxKind::OpeningRoundBracket) {
         // Could be CREATE TABLE ... AS other_table or CREATE TABLE ... AS SELECT
@@ -1374,5 +1394,48 @@ mod tests {
         assert!(buf.contains("EngineClause"));
         assert!(buf.contains("'`a`'"));
         assert!(buf.contains("'`b`'"));
+    }
+
+    #[test]
+    fn test_create_table_clone_as() {
+        // CREATE TABLE ... CLONE AS source clones schema + data from source.
+        let result = parse(
+            "CREATE TABLE new_db.new_tbl CLONE AS src_db.src_tbl",
+        );
+        assert!(
+            result.errors.is_empty(),
+            "unexpected errors: {:?}",
+            result.errors
+        );
+        let mut buf = String::new();
+        result.tree.print(&mut buf, 0, &result.source);
+        assert!(buf.contains("AsClause"));
+        assert!(buf.contains("'CLONE'"));
+        assert!(buf.contains("'src_db'"));
+        assert!(buf.contains("'src_tbl'"));
+    }
+
+    #[test]
+    fn test_create_table_clone_as_with_engine_override() {
+        let result = parse(
+            "CREATE TABLE t CLONE AS src ENGINE = MergeTree ORDER BY tuple()",
+        );
+        assert!(
+            result.errors.is_empty(),
+            "unexpected errors: {:?}",
+            result.errors
+        );
+    }
+
+    #[test]
+    fn test_create_table_clone_as_with_if_not_exists_and_cluster() {
+        let result = parse(
+            "CREATE TABLE IF NOT EXISTS t ON CLUSTER my_cluster CLONE AS src",
+        );
+        assert!(
+            result.errors.is_empty(),
+            "unexpected errors: {:?}",
+            result.errors
+        );
     }
 }

--- a/src/parser/grammar/create_table.rs
+++ b/src/parser/grammar/create_table.rs
@@ -52,21 +52,17 @@ pub fn parse_create_statement(p: &mut Parser) {
         parse_create_role(p);
     } else if p.at_keyword(Keyword::Quota) {
         parse_create_quota(p);
-    } else if p.at_keyword(Keyword::Row) {
+    } else if p.at_keyword(Keyword::Row) || p.at_keyword(Keyword::Policy) {
         parse_create_row_policy(p);
-    } else if p.at_keyword(Keyword::Policy) {
-        parse_create_row_policy(p);
-    } else if p.at_keyword(Keyword::Settings) && !is_temporary {
+    } else if (p.at_keyword(Keyword::Settings) && !is_temporary)
+        || p.at_keyword(Keyword::Profile)
+    {
         parse_create_settings_profile(p);
-    } else if p.at_keyword(Keyword::Profile) {
-        parse_create_settings_profile(p);
+    } else if is_temporary {
+        // TEMPORARY only valid with TABLE
+        p.recover_with_error("Expected TABLE after TEMPORARY");
     } else {
-        if is_temporary {
-            // TEMPORARY only valid with TABLE
-            p.recover_with_error("Expected TABLE after TEMPORARY");
-        } else {
-            p.advance_with_error("Expected TABLE, DATABASE, VIEW, MATERIALIZED VIEW, FUNCTION, or DICTIONARY");
-        }
+        p.advance_with_error("Expected TABLE, DATABASE, VIEW, MATERIALIZED VIEW, FUNCTION, or DICTIONARY");
     }
 
     p.complete(m, SyntaxKind::CreateStatement);
@@ -867,10 +863,8 @@ fn parse_settings_clause(p: &mut Parser) {
             break;
         }
 
-        if !first {
-            if !p.eat(SyntaxKind::Comma) {
-                break;
-            }
+        if !first && !p.eat(SyntaxKind::Comma) {
+            break;
         }
         first = false;
 

--- a/src/parser/grammar/expressions.rs
+++ b/src/parser/grammar/expressions.rs
@@ -1,6 +1,6 @@
 use crate::parser::syntax_kind::SyntaxKind;
 use crate::parser::grammar::common::parse_optional_settings_clause;
-use crate::parser::grammar::select::{at_end_of_column_list, at_select_statement, parse_select_statement};
+use crate::parser::grammar::select::{at_end_of_column_list, at_select_statement, nth_is_clause_keyword, parse_select_statement};
 use crate::parser::grammar::types::parse_column_type;
 use crate::parser::interval_unit::IntervalUnit;
 use crate::parser::keyword::Keyword;
@@ -197,6 +197,11 @@ fn parse_expression_rec(p: &mut Parser, min_bp: u8) {
             //   - a numeric index after an identifier chain: a.b.1
             //   - qualified asterisk: t1.*
             //   - JSON typed path access: json.path.:Type
+            // A clause keyword after the dot (`t.|FROM ...`) is never a valid
+            // field access; stop so the clause can be recognized.
+            if nth_is_clause_keyword(p, 1) {
+                break;
+            }
             if p.nth(1) == SyntaxKind::Colon {
                 // JSON typed path access: expr.:Type
                 let m = p.precede(lhs);
@@ -494,12 +499,16 @@ fn expr_delimited(p: &mut Parser) -> Option<CompletedMarker> {
             // json.path.field).  Stops when the segment after a dot is NOT an
             // identifier — numeric tuple indices (a.1) are left for the
             // DotAccessExpression postfix handler, matching ClickHouse semantics.
+            // Also stops when the segment after the dot is an unambiguous SELECT
+            // clause keyword (FROM, WHERE, ...): live-edit scenarios like
+            // `SELECT t.|FROM x` must not swallow the next clause.
             else if !at_end_of_column_list(p) {
                 let m = p.start();
                 p.advance();
                 while p.at(SyntaxKind::Dot)
                     && (p.nth(1) == SyntaxKind::BareWord
                         || p.nth(1) == SyntaxKind::QuotedIdentifier)
+                    && !nth_is_clause_keyword(p, 1)
                     && !p.eof()
                 {
                     p.advance(); // consume .

--- a/src/parser/grammar/expressions.rs
+++ b/src/parser/grammar/expressions.rs
@@ -363,8 +363,9 @@ fn parse_expression_postfix(p: &mut Parser, mut lhs: CompletedMarker, min_bp: u8
     }
 
     // Ternary operator: expr ? expr : expr
-    // Lowest precedence — handled after all binary operators.
-    if p.at(SyntaxKind::QuestionMark) && 0 >= min_bp {
+    // Lowest precedence — only engage at the outermost level (min_bp == 0),
+    // so a ternary nested inside a higher-precedence operator stops here.
+    if p.at(SyntaxKind::QuestionMark) && min_bp == 0 {
         let m = p.precede(lhs);
         p.advance(); // consume ?
         parse_expression(p); // middle ("then") expression

--- a/src/parser/grammar/select.rs
+++ b/src/parser/grammar/select.rs
@@ -361,21 +361,19 @@ fn parse_select_clause(p: &mut Parser) {
     p.expect_keyword(Keyword::Select);
 
     // DISTINCT [ON (...)]
-    if p.eat_keyword(Keyword::Distinct) {
-        if p.at_keyword(Keyword::On) {
-            p.advance(); // consume ON
-            p.expect(SyntaxKind::OpeningRoundBracket);
-            // parse comma-separated column list inside parens
-            let mut first = true;
-            while !p.at(SyntaxKind::ClosingRoundBracket) && !p.eof() && !p.end_of_statement() {
-                if !first {
-                    p.expect(SyntaxKind::Comma);
-                }
-                first = false;
-                parse_expression(p);
+    if p.eat_keyword(Keyword::Distinct) && p.at_keyword(Keyword::On) {
+        p.advance(); // consume ON
+        p.expect(SyntaxKind::OpeningRoundBracket);
+        // parse comma-separated column list inside parens
+        let mut first = true;
+        while !p.at(SyntaxKind::ClosingRoundBracket) && !p.eof() && !p.end_of_statement() {
+            if !first {
+                p.expect(SyntaxKind::Comma);
             }
-            p.expect(SyntaxKind::ClosingRoundBracket);
+            first = false;
+            parse_expression(p);
         }
+        p.expect(SyntaxKind::ClosingRoundBracket);
     }
 
     parse_column_list(p);
@@ -698,11 +696,10 @@ fn parse_group_by_clause(p: &mut Parser) {
         // WITH TOTALS | WITH ROLLUP | WITH CUBE
         if p.at_keyword(Keyword::With) {
             p.advance(); // consume WITH
-            if p.at_keyword(Keyword::Totals) {
-                p.advance();
-            } else if p.at_keyword(Keyword::Rollup) {
-                p.advance();
-            } else if p.at_keyword(Keyword::Cube) {
+            if p.at_keyword(Keyword::Totals)
+                || p.at_keyword(Keyword::Rollup)
+                || p.at_keyword(Keyword::Cube)
+            {
                 p.advance();
             } else {
                 p.recover_with_error("Expected TOTALS, ROLLUP, or CUBE after WITH");
@@ -1006,10 +1003,7 @@ fn parse_limit_clause(p: &mut Parser) {
     p.expect_keyword(Keyword::Limit);
     parse_expression(p);
 
-    if p.at_keyword(Keyword::Offset) {
-        p.advance();
-        parse_expression(p);
-    } else if p.at(SyntaxKind::Comma) {
+    if p.at_keyword(Keyword::Offset) || p.at(SyntaxKind::Comma) {
         p.advance();
         parse_expression(p);
     }

--- a/src/parser/grammar/select.rs
+++ b/src/parser/grammar/select.rs
@@ -186,6 +186,32 @@ pub fn at_end_of_column_list(p: &mut Parser) -> bool {
         || p.at_keyword(Keyword::Intersect)
 }
 
+/// True if the token at lookahead position `n` is a SELECT-statement clause
+/// keyword that unambiguously starts a new clause. Used by expression
+/// parsers to avoid consuming a clause keyword as if it were an identifier
+/// (e.g. `SELECT t.|FROM x` — the adjacent `FROM` must not be swallowed
+/// into the qualified column reference).
+pub fn nth_is_clause_keyword(p: &mut Parser, n: usize) -> bool {
+    if p.nth(n) != SyntaxKind::BareWord {
+        return false;
+    }
+    let text = p.nth_text(n);
+    for kw in SELECT_CLAUSE_KEYWORDS {
+        if text.eq_ignore_ascii_case(kw.as_str()) {
+            return true;
+        }
+    }
+    // Unambiguous join-starter keywords. Ambiguous ones like LEFT/RIGHT/ANY
+    // are excluded because they double as function names, so treating them
+    // as clause-terminators mid-expression would over-recover.
+    for kw in &[Keyword::Join, Keyword::Inner, Keyword::Cross, Keyword::Natural] {
+        if text.eq_ignore_ascii_case(kw.as_str()) {
+            return true;
+        }
+    }
+    false
+}
+
 const SELECT_CLAUSE_KEYWORDS: &[Keyword] = &[
     Keyword::Select, Keyword::From, Keyword::Where, Keyword::Order,
     Keyword::Limit, Keyword::Group, Keyword::Having, Keyword::Prewhere,

--- a/src/parser/grammar/show.rs
+++ b/src/parser/grammar/show.rs
@@ -148,9 +148,7 @@ pub fn parse_describe_statement(p: &mut Parser) {
     let m = p.start();
 
     // DESCRIBE or DESC
-    if p.at_keyword(Keyword::Describe) {
-        p.advance();
-    } else if p.at_keyword(Keyword::Desc) {
+    if p.at_keyword(Keyword::Describe) || p.at_keyword(Keyword::Desc) {
         p.advance();
     }
 
@@ -461,9 +459,7 @@ fn parse_show_settings(p: &mut Parser) {
 fn parse_like_clause(p: &mut Parser) {
     let m = p.start();
 
-    if p.at_keyword(Keyword::Like) {
-        p.advance();
-    } else if p.at_keyword(Keyword::Ilike) {
+    if p.at_keyword(Keyword::Like) || p.at_keyword(Keyword::Ilike) {
         p.advance();
     }
 
@@ -595,10 +591,8 @@ fn parse_settings_list(p: &mut Parser) {
         && !at_show_statement(p)
         && !at_describe_statement(p)
     {
-        if !first {
-            if !p.eat(SyntaxKind::Comma) {
-                break;
-            }
+        if !first && !p.eat(SyntaxKind::Comma) {
+            break;
         }
         first = false;
 

--- a/src/parser/grammar/statements.rs
+++ b/src/parser/grammar/statements.rs
@@ -141,15 +141,12 @@ pub fn parse_drop_statement(p: &mut Parser) {
 
     // Object kind: TABLE, DATABASE, VIEW, DICTIONARY, FUNCTION
     // TABLE is optional for DROP TABLE
-    if p.at_keyword(Keyword::Table) {
-        p.advance();
-    } else if p.at_keyword(Keyword::Database) {
-        p.advance();
-    } else if p.at_keyword(Keyword::View) {
-        p.advance();
-    } else if p.at_keyword(Keyword::Dictionary) {
-        p.advance();
-    } else if p.at_keyword(Keyword::Function) {
+    if p.at_keyword(Keyword::Table)
+        || p.at_keyword(Keyword::Database)
+        || p.at_keyword(Keyword::View)
+        || p.at_keyword(Keyword::Dictionary)
+        || p.at_keyword(Keyword::Function)
+    {
         p.advance();
     }
     // If none matched, that's ok -- DROP [IF EXISTS] name is valid shorthand
@@ -264,13 +261,11 @@ pub fn parse_exists_statement(p: &mut Parser) {
     let _ = p.eat_keyword(Keyword::Temporary);
 
     // Optional object type keyword
-    if p.at_keyword(Keyword::Table) {
-        p.advance();
-    } else if p.at_keyword(Keyword::Database) {
-        p.advance();
-    } else if p.at_keyword(Keyword::View) {
-        p.advance();
-    } else if p.at_keyword(Keyword::Dictionary) {
+    if p.at_keyword(Keyword::Table)
+        || p.at_keyword(Keyword::Database)
+        || p.at_keyword(Keyword::View)
+        || p.at_keyword(Keyword::Dictionary)
+    {
         p.advance();
     }
 
@@ -362,9 +357,7 @@ pub fn parse_attach_statement(p: &mut Parser) {
     p.expect_keyword(Keyword::Attach);
 
     // Object kind: TABLE, DATABASE
-    if p.at_keyword(Keyword::Table) {
-        p.advance();
-    } else if p.at_keyword(Keyword::Database) {
+    if p.at_keyword(Keyword::Table) || p.at_keyword(Keyword::Database) {
         p.advance();
     }
 
@@ -390,9 +383,7 @@ pub fn parse_detach_statement(p: &mut Parser) {
     p.expect_keyword(Keyword::Detach);
 
     // Object kind: TABLE, DATABASE
-    if p.at_keyword(Keyword::Table) {
-        p.advance();
-    } else if p.at_keyword(Keyword::Database) {
+    if p.at_keyword(Keyword::Table) || p.at_keyword(Keyword::Database) {
         p.advance();
     }
 
@@ -465,9 +456,7 @@ pub fn parse_backup_statement(p: &mut Parser) {
     p.expect_keyword(Keyword::Backup);
 
     // Object kind: TABLE, DATABASE
-    if p.at_keyword(Keyword::Table) {
-        p.advance();
-    } else if p.at_keyword(Keyword::Database) {
+    if p.at_keyword(Keyword::Table) || p.at_keyword(Keyword::Database) {
         p.advance();
     }
 
@@ -511,9 +500,7 @@ pub fn parse_restore_statement(p: &mut Parser) {
     p.expect_keyword(Keyword::Restore);
 
     // Object kind: TABLE, DATABASE
-    if p.at_keyword(Keyword::Table) {
-        p.advance();
-    } else if p.at_keyword(Keyword::Database) {
+    if p.at_keyword(Keyword::Table) || p.at_keyword(Keyword::Database) {
         p.advance();
     }
 
@@ -866,9 +853,7 @@ pub fn parse_system_statement(p: &mut Parser) {
     if is_flush_logs {
         // FLUSH LOGS can have comma-separated log target list: query_log, trace_log
         while !p.end_of_statement() {
-            if p.at_identifier() {
-                p.advance();
-            } else if p.at(SyntaxKind::Comma) {
+            if p.at_identifier() || p.at(SyntaxKind::Comma) {
                 p.advance();
             } else {
                 break;
@@ -907,9 +892,7 @@ pub fn parse_kill_statement(p: &mut Parser) {
 
     // QUERY or MUTATION — wrap in KillTarget
     let target = p.start();
-    if p.at_keyword(Keyword::Query) {
-        p.advance();
-    } else if p.at_keyword(Keyword::Mutation) {
+    if p.at_keyword(Keyword::Query) || p.at_keyword(Keyword::Mutation) {
         p.advance();
     } else {
         p.recover_with_error("Expected QUERY or MUTATION after KILL");

--- a/src/parser/grammar/types.rs
+++ b/src/parser/grammar/types.rs
@@ -45,19 +45,25 @@ pub fn parse_column_type(p: &mut Parser) {
 fn parse_type_parameter(p: &mut Parser) {
     if p.at(SyntaxKind::BareWord) {
         if p.at_keyword(Keyword::Skip) {
-            // SKIP path — JSON type parameter to skip a path.
-            // Consume SKIP keyword and the path identifier(s).
+            // SKIP <path> | SKIP REGEXP '<pattern>' — JSON type parameters
+            // that tell the engine not to materialise certain paths.
             p.advance(); // consume SKIP
-            // The path can be a dot-separated identifier or a REGEXP pattern
-            if p.at(SyntaxKind::BareWord) {
-                p.advance(); // consume path name
-                // Handle dot-separated paths like SKIP a.b.c
+            if p.at(SyntaxKind::BareWord)
+                && p.nth_text(0).eq_ignore_ascii_case("REGEXP")
+            {
+                p.advance(); // consume REGEXP
+                if p.at(SyntaxKind::StringToken) {
+                    p.advance();
+                } else {
+                    p.recover_with_error("Expected string literal after SKIP REGEXP");
+                }
+            } else if p.at(SyntaxKind::BareWord) {
+                p.advance(); // consume first path segment
                 while p.at(SyntaxKind::Dot) && p.nth(1) == SyntaxKind::BareWord {
                     p.advance(); // consume .
                     p.advance(); // consume identifier
                 }
             } else if p.at(SyntaxKind::StringToken) {
-                // SKIP REGEXP 'pattern' — already consumed SKIP, string follows
                 p.advance();
             }
         } else if p.nth(1) == SyntaxKind::Equals {
@@ -293,5 +299,32 @@ mod tests {
                             'String'
                           ')'
         "#]]);
+    }
+
+    #[test]
+    fn json_type_with_skip_regexp() {
+        // SKIP REGEXP 'pattern' inside a JSON(...) parameter list.
+        // Previously flagged with a red squiggle because REGEXP was consumed
+        // as the path and the string became a stray token.
+        let result = parse(
+            "CREATE TABLE t (c JSON(max_dynamic_paths=0, SKIP REGEXP 'utm_.*', loc String)) ENGINE = MergeTree ORDER BY tuple()",
+        );
+        assert!(
+            result.errors.is_empty(),
+            "unexpected errors: {:?}",
+            result.errors
+        );
+    }
+
+    #[test]
+    fn json_type_with_skip_path_still_works() {
+        let result = parse(
+            "CREATE TABLE t (c JSON(SKIP some.nested.path, a String)) ENGINE = MergeTree ORDER BY tuple()",
+        );
+        assert!(
+            result.errors.is_empty(),
+            "unexpected errors: {:?}",
+            result.errors
+        );
     }
 }

--- a/src/parser/keyword.rs
+++ b/src/parser/keyword.rs
@@ -320,6 +320,9 @@ pub enum Keyword {
     Setting,
     Reset,
     Option,
+
+    // CREATE TABLE ... CLONE AS
+    Clone,
 }
 
 impl Keyword {
@@ -561,6 +564,7 @@ impl Keyword {
             Keyword::Reset => "RESET",
             Keyword::Option => "OPTION",
             Keyword::Cleanup => "CLEANUP",
+            Keyword::Clone => "CLONE",
         }
     }
 }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -65,14 +65,9 @@ impl Parser {
         for i in 0..event_count {
             if let Event::Open { forward_parent: Some(_), .. } = &events[i] {
                 let mut cur = i;
-                loop {
-                    match &events[cur] {
-                        Event::Open { forward_parent: Some(next), .. } => {
-                            opened_via_fp[*next as usize] = true;
-                            cur = *next as usize;
-                        }
-                        _ => break,
-                    }
+                while let Event::Open { forward_parent: Some(next), .. } = &events[cur] {
+                    opened_via_fp[*next as usize] = true;
+                    cur = *next as usize;
                 }
             }
         }
@@ -90,14 +85,9 @@ impl Parser {
                         // Collect the chain: self -> fp1 -> fp2 -> ... -> last
                         let mut chain = vec![i];
                         let mut cur = i;
-                        loop {
-                            match &events[cur] {
-                                Event::Open { forward_parent: Some(next), .. } => {
-                                    chain.push(*next as usize);
-                                    cur = *next as usize;
-                                }
-                                _ => break,
-                            }
+                        while let Event::Open { forward_parent: Some(next), .. } = &events[cur] {
+                            chain.push(*next as usize);
+                            cur = *next as usize;
                         }
                         // Open wrapper nodes from outermost (end of chain) to innermost,
                         // then the original node last
@@ -216,35 +206,23 @@ impl Parser {
             forward_parent: None,
         });
         // Point the original node's Open event to the new wrapper
-        match &mut self.events[m.index] {
-            Event::Open { forward_parent: _, .. } => {
-                // Follow any existing chain to the end
-                let mut target = m.index;
-                loop {
-                    match &self.events[target] {
-                        Event::Open { forward_parent: Some(next), .. } => {
-                            target = *next as usize;
-                        }
-                        _ => break,
-                    }
-                }
-                match &mut self.events[target] {
-                    Event::Open { forward_parent, .. } => {
-                        *forward_parent = Some(new_index as u32);
-                    }
-                    _ => {}
-                }
+        if matches!(self.events[m.index], Event::Open { .. }) {
+            // Follow any existing chain to the end
+            let mut target = m.index;
+            while let Event::Open { forward_parent: Some(next), .. } = &self.events[target] {
+                target = *next as usize;
             }
-            _ => {}
+            if let Event::Open { forward_parent, .. } = &mut self.events[target] {
+                *forward_parent = Some(new_index as u32);
+            }
         }
         Marker { index: new_index }
     }
 
     /// Retroactively change the SyntaxKind of an already-completed node.
     pub fn change_kind(&mut self, m: CompletedMarker, kind: SyntaxKind) {
-        match &mut self.events[m.index] {
-            Event::Open { kind: k, .. } => *k = kind,
-            _ => {}
+        if let Event::Open { kind: k, .. } = &mut self.events[m.index] {
+            *k = kind;
         }
     }
 
@@ -257,9 +235,8 @@ impl Parser {
     }
 
     pub fn complete(&mut self, m: Marker, kind: SyntaxKind) -> CompletedMarker {
-        match &mut self.events[m.index] {
-            Event::Open { kind: k, .. } => *k = kind,
-            _ => {}
+        if let Event::Open { kind: k, .. } = &mut self.events[m.index] {
+            *k = kind;
         }
         self.events.push(Event::Close);
         CompletedMarker { index: m.index }

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -933,6 +933,59 @@ fn format_clause_after_having() {
 }
 
 #[test]
+fn column_named_like_keyword_preserves_case() {
+    // A column named `type` (a keyword) must not be uppercased by the formatter.
+    check_format(
+        "select t.type from t",
+        expect![[r#"
+            SELECT
+                t.type
+            FROM t
+        "#]],
+    );
+}
+
+#[test]
+fn table_alias_named_like_keyword_preserves_case() {
+    // An alias named `final` (a keyword) must not be uppercased.
+    // (note: ClickHouse treats `final` as a soft keyword usable as alias)
+    check_format(
+        "select a from t as type",
+        expect![[r#"
+            SELECT
+                a
+            FROM t AS type
+        "#]],
+    );
+}
+
+#[test]
+fn qualified_table_with_keyword_parts_preserves_case() {
+    // A fully-qualified table where parts match keywords must not be uppercased.
+    check_format(
+        "select * from system.type",
+        expect![[r#"
+            SELECT
+                *
+            FROM system.type
+        "#]],
+    );
+}
+
+#[test]
+fn column_alias_named_like_keyword_preserves_case() {
+    // An output alias like `AS type` must not have the alias name uppercased.
+    check_format(
+        "select a as type from t",
+        expect![[r#"
+            SELECT
+                a AS type
+            FROM t
+        "#]],
+    );
+}
+
+#[test]
 fn idempotent_codec_types() {
     check_idempotent("CREATE TABLE t (`ts` DateTime64(9) CODEC(Delta(8), ZSTD(1))) ENGINE = MergeTree() ORDER BY ts");
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3218,3 +3218,74 @@ fn with_totals_in_subquery_test() {
         expect![[""]],
     );
 }
+
+// ====================================================================
+// SELECT-clause resilience — in-flight edits must not eat the FROM
+// ====================================================================
+
+/// Assert that the given SQL, however malformed, produces a tree that
+/// contains a FromClause pointing at the expected table name.
+fn assert_from_clause_with_table(sql: &str, expected_table: &str) {
+    let result = parse(sql);
+    let mut buf = String::new();
+    result.tree.print(&mut buf, 0, &result.source);
+    assert!(
+        buf.contains("FromClause"),
+        "FROM clause should survive SELECT error recovery for {:?}\n{}",
+        sql,
+        buf
+    );
+    assert!(
+        buf.contains(expected_table),
+        "table {:?} should be preserved in tree for {:?}\n{}",
+        expected_table,
+        sql,
+        buf
+    );
+}
+
+#[test]
+fn resilience_dot_immediately_before_from() {
+    // `t.FROM` used to be consumed as a qualified column; the FROM clause
+    // must survive as a sibling.
+    assert_from_clause_with_table("SELECT t.FROM mytable AS t", "mytable");
+}
+
+#[test]
+fn resilience_dot_with_space_before_from() {
+    assert_from_clause_with_table("SELECT t. FROM mytable AS t", "mytable");
+}
+
+#[test]
+fn resilience_trailing_dot_before_from() {
+    // User paused after typing a dot, the FROM is on a new line.
+    assert_from_clause_with_table("SELECT t.\nFROM mytable AS t", "mytable");
+}
+
+#[test]
+fn resilience_dot_before_where() {
+    assert_from_clause_with_table("SELECT t. FROM mytable AS t WHERE 1=1", "mytable");
+}
+
+#[test]
+fn resilience_dot_before_group_by() {
+    assert_from_clause_with_table(
+        "SELECT t. FROM mytable AS t GROUP BY 1",
+        "mytable",
+    );
+}
+
+#[test]
+fn resilience_trailing_comma_in_select() {
+    assert_from_clause_with_table("SELECT a, b, FROM mytable", "mytable");
+}
+
+#[test]
+fn resilience_double_comma_in_select() {
+    assert_from_clause_with_table("SELECT a,, b FROM mytable", "mytable");
+}
+
+#[test]
+fn resilience_bare_as_without_alias() {
+    assert_from_clause_with_table("SELECT a AS FROM mytable", "mytable");
+}


### PR DESCRIPTION
 - Formatter upper-cased identifiers that matched keywords. t.type, AS
  type, system.type were emitted as t.TYPE, AS TYPE, SYSTEM.TYPE — which
  changes the query's meaning or requires backticks that the user didn't
  write. Track an identifier_depth in FormatterContext; BareWords inside
  TableIdentifier / ColumnReference / QualifiedName / the name slot of
  TableAlias/ColumnAlias are never re-cased. Clause-keyword positions are
  unaffected.
  - Dot-access missed when cursor sat at a token boundary. Live-typing
  SELECT t. with FROM adjacent produced SELECT t.|FROM …;
  token_before_offset used token.start <= offset so it picked the next token
   as "prev" and completion fired as a plain select expression. Switched to
  token.end <= offset in token_before_impl and find_ident_before_dot_impl.
  - SELECT clause swallowed adjacent clause keywords. SELECT t.|FROM x was
  parsed as a qualified column t.FROM, destroying the FROM clause and
  blanking the scope. Added select::nth_is_clause_keyword(p, n); guarded
  both the identifier chain in expr_delimited and the postfix Dot branch in
  parse_expression_rec.
  - No columns inside subqueries, no projection through subquery aliases.
  scope_at now uses find_enclosing_statement, so a cursor inside a subquery
  gets the subquery's own scope. Added QueryScope::subquery_refs; when a
  TableAlias follows a SubqueryExpression, we record (alias, columns) with
  columns taken from the subquery's top-level SELECT list (AS-aliases
  preferred, trailing identifier otherwise). Completion surfaces those
  columns directly.
  - JSON(..., SKIP REGEXP 'pattern', ...) flagged a red squiggle. The SKIP
  handler accepted SKIP path and SKIP 'str' but not the three-token SKIP
  REGEXP 'pat' form, so REGEXP was consumed as the path and the string was
  left stray. Match the REGEXP keyword specifically and require a string
  literal after it.
  - CREATE TABLE … CLONE AS source flagged Unexpected token in CREATE
  statement. Added the Clone keyword and a CLONE AS <source> branch in
  parse_create_table that wraps the source as an AsClause and falls through
  to standard ENGINE = … / ORDER BY … handling for optional overrides.
 - Connected server posted "Only SELECT is supported for EXPLAIN query" on every non-SELECT statement. publish_diagnostics validated anything whose source text started with SELECT/WITH/INSERT by running EXPLAIN PLAN, but ClickHouse
  only accepts EXPLAIN for SELECT (and UNION of SELECTs). Every INSERT/CREATE/ALTER/etc. in a connected workspace got a yellow squiggle with a server error the user couldn't act on. Filter on the CST statement kind (SelectStatement
  or UnionClause) instead of text prefixes.
- Fix clippy test failing to run
- Fix all clippy warning